### PR TITLE
#350 [RegistrationCertificate] add: draft cache to persist API payload & coherent error messages

### DIFF
--- a/class/registrationcertificatefr.class.php
+++ b/class/registrationcertificatefr.class.php
@@ -63,6 +63,7 @@ class RegistrationCertificateFr extends SaturneObject
      */
     public string $picto = 'fontawesome_fa-car_fas_#d35968';
 
+    public const STATUS_DRAFT     = -2;
     public const STATUS_DELETED   = -1;
     public const STATUS_VALIDATED = 1;
     public const STATUS_LOCKED    = 2;
@@ -307,8 +308,10 @@ class RegistrationCertificateFr extends SaturneObject
         global $langs;
 
         $registrationNumber          = normalize_registration_number(dol_strtoupper($this->a_registration_number));
-        $this->ref                   = $registrationNumber;
         $this->a_registration_number = $registrationNumber;
+        // DRAFT rows act as a hidden API-payload cache keyed by plaque. Prefix the ref so that
+        // the validated clone (which uses plaque as ref) does not collide with the draft.
+        $this->ref = ($this->status == self::STATUS_DRAFT) ? 'DRAFT_' . $registrationNumber : $registrationNumber;
 
         if (empty($this->fk_product) || $this->fk_product == -1) {
             $this->fk_product = getDolGlobalInt('DOLICAR_DEFAULT_VEHICLE');
@@ -357,10 +360,12 @@ class RegistrationCertificateFr extends SaturneObject
             global $langs;
 
             $this->labelStatus[self::STATUS_DELETED]   = $langs->transnoentitiesnoconv('Deleted');
+            $this->labelStatus[self::STATUS_DRAFT]     = $langs->transnoentitiesnoconv('Draft');
             $this->labelStatus[self::STATUS_VALIDATED] = $langs->transnoentitiesnoconv('Enabled');
             $this->labelStatus[self::STATUS_ARCHIVED]  = $langs->transnoentitiesnoconv('Archived');
 
             $this->labelStatusShort[self::STATUS_DELETED]   = $langs->transnoentitiesnoconv('Deleted');
+            $this->labelStatusShort[self::STATUS_DRAFT]     = $langs->transnoentitiesnoconv('Draft');
             $this->labelStatusShort[self::STATUS_VALIDATED] = $langs->transnoentitiesnoconv('Enabled');
             $this->labelStatusShort[self::STATUS_ARCHIVED]  = $langs->transnoentitiesnoconv('Archived');
         }
@@ -390,20 +395,39 @@ class RegistrationCertificateFr extends SaturneObject
         if (dol_strlen($searchValue) > 0) {
             if ($searchType == 'plaque') {
                 $searchValue = normalize_registration_number($searchValue);
-                $result = $this->fetch(0, $searchValue);
-                if ($result > 0) {
-                    setEventMessages($langs->trans('LicencePlateWasAlreadyExisting'), []);
-                    header('Location: ' . dol_buildpath('dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $this->id);
-                    exit;
-                }
+                $plaqueFilter = $searchValue;
+                $vinFilter    = '';
             } else {
-                $result = $this->fetch(0, '', ' AND e_vehicle_serial_number = "' . $db->escape($searchValue) . '"');
-                if ($result > 0) {
-                    setEventMessages($langs->trans('LicencePlateWasAlreadyExisting'), []);
-                    header('Location: ' . dol_buildpath('dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $this->id);
-                    exit;
-                }
+                $plaqueFilter = '';
+                $vinFilter    = $searchValue;
             }
+
+            // First, look up any existing DRAFT (hidden cache row) for this plaque/VIN and reuse its stored API payload.
+            $draftFilter = ' AND status = ' . self::STATUS_DRAFT;
+            if ($plaqueFilter !== '') {
+                $draftFilter .= ' AND a_registration_number = "' . $db->escape($plaqueFilter) . '"';
+            } else {
+                $draftFilter .= ' AND e_vehicle_serial_number = "' . $db->escape($vinFilter) . '"';
+            }
+            $draftCache = new self($this->db);
+            if ($draftCache->fetch(0, '', $draftFilter) > 0 && !empty($draftCache->json)) {
+                // Do NOT populate $this here: the caller will create a fresh VALIDATED row from the returned payload.
+                return ['api' => $api, 'data' => json_decode($draftCache->json), 'cached' => true, 'draft_id' => $draftCache->id];
+            }
+
+            // Then, look up an already-validated certificate and redirect to it.
+            if ($plaqueFilter !== '') {
+                $result = $this->fetch(0, $plaqueFilter);
+            } else {
+                $result = $this->fetch(0, '', ' AND e_vehicle_serial_number = "' . $db->escape($vinFilter) . '"');
+            }
+            if ($result > 0 && $this->status != self::STATUS_DRAFT) {
+                setEventMessages($langs->trans('LicencePlateWasAlreadyExisting'), []);
+                header('Location: ' . dol_buildpath('dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $this->id);
+                exit;
+            }
+            // Reset $this in case fetch populated it with unrelated data
+            $this->id = 0;
         }
 
         if ($api == 'apiplaqueimmatriculation.com') {

--- a/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
+++ b/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
@@ -57,6 +57,35 @@ $apiData = $object->getRegistrationCertificateData($searchValue, $searchType);
 $registrationCertificateObject = isset($apiData['data']) ? $apiData['data'] : null;
 $api = isset($apiData['api']) ? $apiData['api'] : '';
 $error = isset($apiData['error']) ? $apiData['error'] : '';
+$cachedDraft = !empty($apiData['cached']);
+
+// Inform the user when cached data is being reused (no API token consumed this time).
+if ($cachedDraft && is_object($registrationCertificateObject)) {
+    setEventMessages($langs->trans('LicencePlateDraftCacheHit'), [], 'mesgs');
+}
+
+// Persist raw API payload as a hidden DRAFT row (cache) so a failure during product/lot creation does not lose the data.
+// On retry with the same plaque/VIN, getRegistrationCertificateData() reuses this draft instead of calling the API again.
+// The DRAFT lives in a separate row with a prefixed ref; the VALIDATED certificate is created later as a clone ($object).
+if (!$error && is_object($registrationCertificateObject) && !$cachedDraft) {
+    if ($api == 'apiplaqueimmatriculation.com') {
+        $draftPlaque = !empty($registrationCertificateObject->plaque) ? $registrationCertificateObject->plaque : $registrationNumber;
+        $draftVin    = !empty($registrationCertificateObject->vin) ? $registrationCertificateObject->vin : $vinNumber;
+    } else {
+        $draftPlaque = !empty($registrationNumber) ? $registrationNumber : $searchValue;
+        $draftVin    = (!empty($registrationCertificateObject->ExtendedData) && !empty($registrationCertificateObject->ExtendedData->numSerieMoteur)) ? $registrationCertificateObject->ExtendedData->numSerieMoteur : $vinNumber;
+    }
+    if (!empty($draftPlaque)) {
+        $draftCache                          = new RegistrationCertificateFr($db);
+        $draftCache->a_registration_number   = $draftPlaque;
+        $draftCache->e_vehicle_serial_number = $draftVin;
+        $draftCache->json                    = json_encode($registrationCertificateObject);
+        $draftCache->status                  = RegistrationCertificateFr::STATUS_DRAFT;
+        if ($draftCache->create($user) <= 0) {
+            setEventMessages($langs->trans('LicencePlateDraftSaveFailed'), [], 'warnings');
+        }
+    }
+}
 
 
 if ($api == 'apiplaqueimmatriculation.com') {
@@ -151,6 +180,11 @@ if ($api == 'apiplaqueimmatriculation.com') {
                 $object->json = json_encode($registrationCertificateObject);
 
                 $registrationCertificateId = $object->create($user);
+                if ($registrationCertificateId <= 0) {
+                    setEventMessages($langs->trans('LicencePlateCertificateCreationFailed'), $object->errors, 'errors');
+                } else {
+                    setEventMessages($langs->trans('LicencePlateInformationsCharged'), [], 'mesgs');
+                }
 
                 $backtopage = dol_buildpath('custom/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $registrationCertificateId;
             } else {
@@ -269,6 +303,11 @@ if ($api == 'immatriculationapi.com') {
                 $object->json = json_encode($registrationCertificateObject);
 
                 $registrationCertificateId = $object->create($user);
+                if ($registrationCertificateId <= 0) {
+                    setEventMessages($langs->trans('LicencePlateCertificateCreationFailed'), $object->errors, 'errors');
+                } else {
+                    setEventMessages($langs->trans('LicencePlateInformationsCharged'), [], 'mesgs');
+                }
 
                 $backtopage = dol_buildpath('custom/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $registrationCertificateId;
             } else {

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -152,6 +152,9 @@ LessThanHundredApiRequestsRemaining   = Il vous reste moins de 10 jetons de rech
 LicencePlateWasAlreadyExisting        = La plaque d'immatriculation existe déjà, vous avez été redirigé(e) sur sa page.
 BadAPIUsernameOrBadLicencePlateFormat = Mauvais nom d'utilisateur ou format de plaque d'immatriculation. <br> Veuillez utiliser l'un des formats suivants pour la plaque d'immatriculation : <br><b> XX-111-XX <br>  XX111XX </b>
 LicencePlateInformationsCharged       = Les informations de la carte grise ont bien été récupérées
+LicencePlateDraftCacheHit             = Les informations de cette plaque ont été récupérées depuis un brouillon précédent. Aucun jeton API n'a été consommé.
+LicencePlateDraftSaveFailed           = Impossible d'enregistrer le brouillon de la plaque. Un nouvel appel API sera nécessaire en cas de nouvelle tentative.
+LicencePlateCertificateCreationFailed = Erreur lors de la création de la carte grise. Le brouillon a été conservé, vous pouvez réessayer sans consommer de jeton API.
 BadAPIUsername                        = Nom d'utilisateur pour l'API invalide
 
 # QuickCreation - Ajout rapide


### PR DESCRIPTION
## Contexte

Lors de la création d'une plaque d'immatriculation, un appel API payant est effectué avant la création du produit, lot et certificat. Si une étape échoue (ex: l'utilisateur quitte la page pour créer un tiers via le bouton \"+\"), les données de l'API sont perdues et le jeton est consommé pour rien. Au retry, un nouvel appel API était nécessaire et un faux message \"plaque déjà existante\" pouvait apparaître.

Fixes #350

## Summary

- Ajout d'un statut \`STATUS_DRAFT = -2\` qui permet de cacher automatiquement les rows brouillon de la liste (saturne filtre \`t.status >= 0\`)
- Après un appel API réussi, la réponse brute est persistée immédiatement dans une row DRAFT (ref préfixée \`DRAFT_<plaque>\` pour éviter tout conflit avec la future row VALIDATED)
- Avant tout appel API, \`getRegistrationCertificateData()\` cherche d'abord un DRAFT par \`a_registration_number\` (ou VIN) + \`status = DRAFT\` et retourne son JSON caché → **zéro appel API consommé au retry**
- La création VALIDATED finale reste un \`\$object->create()\` classique sur un objet neuf (clone implicite via les données de la réponse API, cachée ou fraîche)
- Messages d'événement cohérents :
  - Info : \"Les informations de cette plaque ont été récupérées depuis un brouillon précédent. Aucun jeton API n'a été consommé.\" (cache hit)
  - Warning : \"Impossible d'enregistrer le brouillon de la plaque...\" (draft save failed)
  - Error : \"Erreur lors de la création de la carte grise. Le brouillon a été conservé, vous pouvez réessayer sans consommer de jeton API.\" (cert create failed)
  - Info : \"Les informations de la carte grise ont bien été récupérées\" (succès)

## Test plan

- [ ] Créer une nouvelle plaque : un DRAFT apparaît en DB (status=-2, invisible dans la liste), puis une VALIDATED après succès
- [ ] Simuler une erreur entre l'API et la création du certificat (ex : click \"+\" tiers puis retour) → DRAFT persisté, jeton conservé au retry
- [ ] Resoumettre la même plaque après abandon → message cache hit, zéro décrément du compteur API
- [ ] Resoumettre une plaque déjà VALIDATED → redirection vers la fiche existante (comportement inchangé)
- [ ] Vérifier que les DRAFT n'apparaissent dans aucune liste/sélecteur

🤖 Generated with [Claude Code](https://claude.com/claude-code)