### PR TITLE
#362 [RegistrationCertificateFr] fix: invalid productlot create link and missing Categorie class

### DIFF
--- a/lib/dolicar_functions.lib.php
+++ b/lib/dolicar_functions.lib.php
@@ -62,6 +62,7 @@ function create_default_product_lot(int $productID): int
 function get_vehicle_brand(int $productID): string
 {
     // Global variables definitions
+    require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
     global $db;
 
     // Initialize technical objects

--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -271,7 +271,7 @@ if (($id || $ref) && $action == 'edit') {
         }
     }
     print img_picto('', 'lot', 'class="pictofixedwidth"') . $form::selectarray('fk_lot', $productLotsData, GETPOST('fk_lot') > 0 ? GETPOST('fk_lot') : $object->fk_lot, $langs->transnoentities('SelectProductLots'), '', '', '', '', '', '','', 'maxwidth500 widthcentpercentminusx');
-    print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/product/stock/productlot_card.php?action=create' . ((GETPOST('fk_product') > 0) ? '&fk_product=' . GETPOST('fk_product') : $object->fk_product) . '&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddProductLot') . '"></span></a>';
+    print '<a class="butActionNew" href="' . DOL_URL_ROOT . '/product/stock/productlot_card.php?action=create' . ((GETPOST('fk_product') > 0) ? '&fk_product=' . GETPOST('fk_product') : ($object->fk_product > 0 ? '&fk_product=' . $object->fk_product : '')) . '&backtopage=' . urlencode($_SERVER['PHP_SELF'] . '?action=create') . '"><span class="fa fa-plus-circle valignmiddle paddingleft" title="' . $langs->trans('AddProductLot') . '"></span></a>';
     print '</td></tr>';
 
     // Common attributes


### PR DESCRIPTION
#362 - Correction du lien productlot create (ternaire mal formee generant action=create9) - Ajout require_once Categorie manquant dans get_vehicle_brand()