### PR TITLE
#358 [ProductLot] feat: show linked registration certificate in banner

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -228,6 +228,30 @@ class ActionsDoliCar
     }
 
     /**
+     * Overloading the formDolBanner function : replacing the parent's function with the one below
+     *
+     * @param  array        $parameters Hook metadatas (context, etc...)
+     * @param  CommonObject $object     Current object
+     * @return int                      0 < on error, 0 on success, 1 to replace standard code
+     */
+    public function formDolBanner(array $parameters, $object): int
+    {
+        if (strpos($parameters['context'], 'productlotcard') !== false) {
+            $registrationCertificateFr = new RegistrationCertificateFr($this->db);
+            $registrationCertificates  = $registrationCertificateFr->fetchAll('', '', 1, 0, ['customsql' => 't.fk_lot = ' . (int) $object->id]);
+
+            if (is_array($registrationCertificates) && !empty($registrationCertificates)) {
+                $registrationCertificateFr = reset($registrationCertificates);
+                $this->resprints  = '<div class="refidno">';
+                $this->resprints .= $registrationCertificateFr->getNomUrl(1);
+                $this->resprints .= '</div>';
+            }
+        }
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
      * Overloading the printCommonFooter function : replacing the parent's function with the one below
      *
      * @param  array $parameters Hook metadatas (context, etc...)

--- a/class/registrationcertificatefr.class.php
+++ b/class/registrationcertificatefr.class.php
@@ -350,6 +350,21 @@ class RegistrationCertificateFr extends SaturneObject
     }
 
     /**
+     * Return tooltip content array
+     *
+     * @param  array $params Tooltip params
+     * @return array         Tooltip content
+     */
+    public function getTooltipContentArray($params): array
+    {
+        global $langs;
+
+        $langs->load('dolicar@dolicar');
+
+        return parent::getTooltipContentArray($params);
+    }
+
+    /**
      * Return the status
      *
      * @param  int    $status ID status


### PR DESCRIPTION
## Changements
- Ajout du hook formDolBanner dans ActionsDoliCar : affiche le lien getNomUrl de la carte grise liee au lot dans le banner de productlot_card.php
- Surcharge de getTooltipContentArray dans RegistrationCertificateFr pour charger le fichier lang dolicar@dolicar et assurer la traduction du tooltip

## Fichiers modifies
- class/actions_dolicar.class.php
- class/registrationcertificatefr.class.php

## Issue
#358