### PR TITLE
#361 [DoliCar] fix: read vin from product lot batch in propal note

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -99,8 +99,10 @@ class ActionsDoliCar
             if ($action == 'add') {
                 if (GETPOSTISSET('options_registrationcertificatefr') && !empty(GETPOST('options_registrationcertificatefr'))) {
                     require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+                    require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
 
-                    $product = new Product($this->db);
+                    $product    = new Product($this->db);
+                    $productLot = new Productlot($this->db);
 
                     $extraFieldsNames = ['registration_number', 'vehicle_model', 'first_registration_date', 'VIN_number', 'linked_product', 'linked_lot'];
                     foreach ($extraFieldsNames as $extraFieldsName) {
@@ -109,10 +111,11 @@ class ActionsDoliCar
 
                     $registrationCertificateFr->fetch(GETPOSTINT('options_registrationcertificatefr'));
                     $product->fetch($registrationCertificateFr->fk_product);
+                    $productLot->fetch($registrationCertificateFr->fk_lot);
 
                     $_POST['options_registration_number'] = $registrationCertificateFr->a_registration_number;
                     $_POST['options_vehicle_model']       = $product->label;
-                    $_POST['options_VIN_number']          = $registrationCertificateFr->e_vehicle_serial_number;
+                    $_POST['options_VIN_number']          = $productLot->batch;
 
                     $bFirstRegistrationDate                        = dol_getdate($registrationCertificateFr->b_first_registration_date);
                     $_POST['options_first_registration_date']      = $bFirstRegistrationDate['mday'] . '/' . $bFirstRegistrationDate['mon'] . '/' . $bFirstRegistrationDate['year'];
@@ -122,22 +125,27 @@ class ActionsDoliCar
 
                     $_POST['options_linked_product'] = $registrationCertificateFr->fk_product;
                     $_POST['options_linked_lot']     = $registrationCertificateFr->fk_lot;
+
+                    $object->array_options['options_VIN_number'] = $productLot->batch;
                 }
             }
 
             if ($action == 'update_extras') {
                 if (GETPOST('attribute') == 'registrationcertificatefr' && !empty(GETPOSTINT('options_registrationcertificatefr'))) {
                     require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+                    require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
 
-                    $product = new Product($this->db);
+                    $product    = new Product($this->db);
+                    $productLot = new Productlot($this->db);
 
                     $registrationCertificateFrId = GETPOSTINT('options_registrationcertificatefr');
                     $registrationCertificateFr->fetch($registrationCertificateFrId);
                     $product->fetch($registrationCertificateFr->fk_product);
+                    $productLot->fetch($registrationCertificateFr->fk_lot);
 
                     $object->array_options['options_registration_number']     = $registrationCertificateFr->a_registration_number;
                     $object->array_options['options_vehicle_model']           = $product->label;
-                    $object->array_options['options_VIN_number']              = $registrationCertificateFr->e_vehicle_serial_number;
+                    $object->array_options['options_VIN_number']              = $productLot->batch;
                     $object->array_options['options_first_registration_date'] = dol_print_date($registrationCertificateFr->b_first_registration_date, 'day');
                     $object->array_options['options_linked_product']          = $registrationCertificateFr->fk_product;
                     $object->array_options['options_linked_lot']              = $registrationCertificateFr->fk_lot;

--- a/core/triggers/interface_99_modDoliCar_DoliCarTriggers.class.php
+++ b/core/triggers/interface_99_modDoliCar_DoliCarTriggers.class.php
@@ -117,7 +117,7 @@ class InterfaceDoliCarTriggers extends DolibarrTriggers
 
                     $object->note_public  = $langs->transnoentities('RegistrationNumber') . ' : ' . (dol_strlen($object->array_options['options_registration_number']) > 0 ? $object->array_options['options_registration_number'] : $langs->transnoentities('NoData')) . '<br>';
                     $object->note_public .= $langs->transnoentities('VehicleModel') . ' : ' . (dol_strlen($object->array_options['options_vehicle_model']) > 0 ? $object->array_options['options_vehicle_model'] : $langs->transnoentities('NoData')) . '<br>';
-                    $object->note_public .= $langs->transnoentities('VINNumber') . ' : ' .  (dol_strlen($object->array_options['options_VIN_number']) > 0 ? $object->array_options['options_VIN_number'] : $langs->transnoentities('NoData')) . '<br>';
+                    $object->note_public .= $langs->transnoentities('VINNumber') . ' : ' . (dol_strlen($object->array_options['options_VIN_number']) > 0 ? $object->array_options['options_VIN_number'] : $langs->transnoentities('NoData')) . '<br>';
                     $object->note_public .= $langs->transnoentities('FirstRegistrationDate') . ' : ' . ($object->array_options['options_first_registration_date'] > 0 ? dol_print_date($object->array_options['options_first_registration_date'], 'day') : $langs->transnoentities('NoData')) . '<br>';
                     $object->note_public .= $langs->transnoentities('Mileage') . ' : ' . ($object->array_options['options_mileage'] > 0 ? price($object->array_options['options_mileage'], 0,'',1, 0) : 0) . ' ' . $langs->trans('km') . '<br>';
 


### PR DESCRIPTION
## Changements
- Lecture du VIN depuis le batch du lot produit lie (productLot->batch) au lieu de e_vehicle_serial_number
- Trigger PROPAL_CREATE/ORDER_CREATE/BILL_CREATE : lecture depuis array_options options_VIN_number
- Bloc update_extras : meme correction pour la mise a jour de la note lors du changement de carte grise

## Fichiers modifies
- class/actions_dolicar.class.php
- core/triggers/interface_99_modDoliCar_DoliCarTriggers.class.php

## Issue
#361