### PR TITLE
#363 [LinkedObjects] feat: show linked objects and digiquali controls on registration cert card

### DIFF
--- a/core/tpl/registrationcertificatefr_linked_objects.tpl.php
+++ b/core/tpl/registrationcertificatefr_linked_objects.tpl.php
@@ -29,6 +29,16 @@
 
 // Load DoliCar libraries
 require_once __DIR__ . '/../../class/registrationcertificatefr.class.php';
+require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+
+// Load DigiQuali libraries if enabled
+$digiqualiEnabled = isModEnabled('digiquali');
+if ($digiqualiEnabled) {
+    require_once DOL_DOCUMENT_ROOT . '/custom/digiquali/class/control.class.php';
+    require_once DOL_DOCUMENT_ROOT . '/custom/digiquali/class/survey.class.php';
+}
+
+$colspanEmpty = $digiqualiEnabled ? 7 : 4;
 
 $out  = load_fiche_titre($langs->transnoentities('LinkedObjects'), '', 'dolicar_color@dolicar');
 $out .= '<table class="noborder centpercent">';
@@ -37,24 +47,85 @@ $out .= '<td>' . $langs->trans('ObjectType') . '</td>';
 $out .= '<td>' . $langs->trans('Object') . '</td>';
 $out .= '<td>' . $langs->trans('Mileage') . '</td>';
 $out .= '<td>' . $langs->trans('Date') . '</td>';
+if ($digiqualiEnabled) {
+    $out .= '<td>' . $langs->trans('Verdict') . '</td>';
+    $out .= '<td>' . $langs->trans('ControlDate') . '</td>';
+    $out .= '<td>' . $langs->trans('NextControlDate') . '</td>';
+}
 $out .= '</tr>';
+
+/**
+ * Helper : render a single linked object row
+ *
+ * @param CommonObject $linkedObject        The linked object to display
+ * @param string       $linkedObjectElement The element type key (e.g. 'digiquali_control')
+ * @param bool         $digiqualiEnabled    Whether DigiQuali module is active
+ * @param Translate    $langs               Translation object
+ * @return string                           HTML row string
+ */
+$renderLinkedObjectRow = static function ($linkedObject, string $linkedObjectElement, bool $digiqualiEnabled, $langs): string {
+    $isControl = ($linkedObjectElement === 'digiquali_control');
+    $isSurvey  = ($linkedObjectElement === 'digiquali_survey');
+
+    $row  = '<tr>';
+    $row .= '<td class="nowrap">' . $langs->transnoentities(ucfirst($linkedObjectElement)) . '</td>';
+    $row .= '<td>' . $linkedObject->getNomUrl(1) . '</td>';
+    $row .= '<td>' . (!$isControl && !$isSurvey ? $linkedObject->array_options['options_mileage'] : '') . '</td>';
+    $row .= '<td>' . dol_print_date($linkedObject->date_creation, 'dayhour') . '</td>';
+    if ($digiqualiEnabled) {
+        if ($isControl) {
+            $verdictColor = $linkedObject->verdict == 1 ? 'green' : ($linkedObject->verdict == 2 ? 'red' : 'grey');
+            $verdictLabel = $linkedObject->fields['verdict']['arrayofkeyval'][!empty($linkedObject->verdict) ? $linkedObject->verdict : 0] ?? 'N/A';
+            $row .= '<td><div class="wpeo-button button-' . $verdictColor . '">' . $langs->trans($verdictLabel) . '</div></td>';
+            $row .= '<td>' . dol_print_date($linkedObject->control_date, 'day') . '</td>';
+            $row .= '<td>' . dol_print_date($linkedObject->next_control_date, 'day') . '</td>';
+        } else {
+            $row .= '<td></td><td></td><td></td>';
+        }
+    }
+    $row .= '</tr>';
+    return $row;
+};
 
 $registrationCertificate = new RegistrationCertificateFr($db);
 $registrationCertificate->fetch(!isset($fromProductLot) ? GETPOST('id') : 0, !isset($fromProductLot) ? GETPOST('ref') : '', isset($fromProductLot) ? ' AND t.fk_lot = ' . GETPOST('id') : '');
-$registrationCertificate->fetchObjectLinked(null, '', $registrationCertificate->id, $registrationCertificate->table_element);
+
+// Collect all rows, keyed by element+id to avoid duplicates
+$rows = [];
+
+// Linked objects directly on the registration certificate
+// No params = OR query: finds links where regcert is source (digiquali controls) AND where it is target (propals, invoices, etc.)
+$registrationCertificate->fetchObjectLinked();
 if (!empty($registrationCertificate->linkedObjects)) {
     foreach ($registrationCertificate->linkedObjects as $linkedObjectElement => $linkedObjects) {
-        foreach ($linkedObjects as $linkedObject) {
-            $out .= '<tr>';
-            $out .= '<td class="nowrap">' . $langs->transnoentities(ucfirst($linkedObjectElement)) . '</td>';
-            $out .= '<td>' . $linkedObject->getNomUrl(1) . '</td>';
-            $out .= '<td>' . $linkedObject->array_options['options_mileage'] . '</td>';
-            $out .= '<td>' . dol_print_date($linkedObject->date_creation, 'dayhour') . '</td>';
-            $out .= '</tr>';
+        foreach ($linkedObjects as $linkedObjectId => $linkedObject) {
+            $rows[$linkedObjectElement . '_' . $linkedObjectId] = $renderLinkedObjectRow($linkedObject, $linkedObjectElement, $digiqualiEnabled, $langs);
         }
     }
+}
+
+// Controls and surveys linked to the associated product lot
+if ($digiqualiEnabled && $registrationCertificate->fk_lot > 0) {
+    $productLotLinked = new Productlot($db);
+    $productLotLinked->fetch($registrationCertificate->fk_lot);
+    // No params = OR query: finds links where lot is source (digiquali controls) AND where it is target
+    $productLotLinked->fetchObjectLinked();
+    foreach (['digiquali_control', 'digiquali_survey'] as $elementType) {
+        if (!empty($productLotLinked->linkedObjects[$elementType])) {
+            foreach ($productLotLinked->linkedObjects[$elementType] as $linkedObjectId => $linkedObject) {
+                $key = $elementType . '_' . $linkedObjectId;
+                if (!isset($rows[$key])) {
+                    $rows[$key] = $renderLinkedObjectRow($linkedObject, $elementType, $digiqualiEnabled, $langs);
+                }
+            }
+        }
+    }
+}
+
+if (!empty($rows)) {
+    $out .= implode('', $rows);
 } else {
-    $out .= '<tr><td colspan="4">' . $langs->trans('NoLinkedObjectsToPrint') . '</td></tr>';
+    $out .= '<tr><td colspan="' . $colspanEmpty . '">' . $langs->trans('NoLinkedObjectsToPrint') . '</td></tr>';
 }
 
 $out .= '</table>'; ?>

--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -379,6 +379,9 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
         }
         print '</div>';
     }
+
+    // Linked objects section
+    require_once __DIR__ . '/../../core/tpl/registrationcertificatefr_linked_objects.tpl.php';
 }
 
 // End of page


### PR DESCRIPTION
## Changements
- Affichage de la liste des objets lies sur la card de la carte grise (comme sur la card du lot)
- Ajout des colonnes DigiQuali (Verdict, Date controle, Prochaine date controle) quand DigiQuali est actif
- Affichage des controles/questionnaires lies au lot associe a la carte grise (avec deduplification)
- Correction fetchObjectLinked : requete OR sans parametres pour trouver les controles (fk_source) ET les propals/factures (fk_target)

## Fichiers modifies
- core/tpl/registrationcertificatefr_linked_objects.tpl.php
- view/registrationcertificatefr/registrationcertificatefr_card.php

## Issue
#363