### PR TITLE
#374 [RegistrationCertificate] fix: skip stock increment when VIN lot already exists

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -34,6 +34,8 @@ if (file_exists('../dolicar.main.inc.php')) {
 require_once __DIR__ . '/../lib/dolicar.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/security.lib.php';
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
 
 // Global variables definitions
 global $conf, $db, $langs, $user;
@@ -51,6 +53,24 @@ $action = GETPOST('action', 'aZ09');
 /*
  * Actions
  */
+
+if ($action == 'update_warehouse') {
+    $error = 0;
+
+    $warehouseId = GETPOSTINT('DOLICAR_DEFAULT_WAREHOUSE_ID');
+    if ($warehouseId > 0) {
+        if (!dolibarr_set_const($db, 'DOLICAR_DEFAULT_WAREHOUSE_ID', $warehouseId, 'integer', 0, '', $conf->entity)) {
+            $error++;
+        }
+    } else {
+        $error++;
+    }
+
+    if (!$error) {
+        setEventMessages($langs->trans('SetupSaved'), null, 'mesgs');
+    }
+    $action = 'edit';
+}
 
 if ($action == 'update') {
 	$error = 0;
@@ -164,6 +184,36 @@ print '</table>';
 
 print '<br><div class="center">';
 print '<input class="button button-save" type="submit" value="' . $langs->trans("Save") . '">';
+print '</div>';
+print '</form>';
+
+// Warehouse configuration section
+print '<br>';
+print load_fiche_titre($langs->transnoentities('WarehouseConfig'), '', '');
+
+print '<form method="POST" action="' . $_SERVER["PHP_SELF"] . '">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<input type="hidden" name="action" value="update_warehouse">';
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->transnoentities('Parameters') . '</td>';
+print '<td class="center">' . $langs->transnoentities('Value') . '</td>';
+print '</tr>';
+
+print '<tr class="oddeven">';
+print '<td class="nowraponall">';
+print $langs->transnoentities('DefaultWarehouseForVehicle') . '<br><span class="opacitymedium">' . $langs->transnoentities('DefaultWarehouseForVehicleDesc') . '</span>';
+print '</td>';
+print '<td class="center">';
+$formproduct = new FormProduct($db);
+print $formproduct->selectWarehouses(getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 'DOLICAR_DEFAULT_WAREHOUSE_ID', '', 1, 0, 0, '', 0, 0, [], 'minwidth300');
+print '</td>';
+print '</tr>';
+print '</table>';
+
+print '<br><div class="center">';
+print '<input class="button button-save" type="submit" value="' . $langs->trans('Save') . '">';
 print '</div>';
 print '</form>';
 

--- a/core/modules/modDoliCar.class.php
+++ b/core/modules/modDoliCar.class.php
@@ -175,6 +175,8 @@ class modDoliCar extends DolibarrModules
             // CONST REGISTRATION CERTIFICATE
             $i++ => ['DOLICAR_REGISTRATIONCERTIFICATEFR_ADDON', 'chaine', 'mod_registrationcertificatefr_standard', '', 0, 'current'],
             $i++ => ['DOLICAR_DEFAULT_WAREHOUSE_ID', 'integer', 0, '', 0, 'current'],
+            $i++ => ['DOLICAR_INTERNE_WAREHOUSE_ID', 'integer', 0, '', 0, 'current'],
+            $i++ => ['DOLICAR_REPARATION_WAREHOUSE_ID', 'integer', 0, '', 0, 'current'],
             $i++ => ['DOLICAR_TAGS_SET', 'integer', 0, '', 0, 'current'],
             $i++ => ['DOLICAR_DEFAULT_VEHICLE_SET', 'integer', 0, '', 0, 'current'],
             $i++ => ['DOLICAR_DEFAULT_VEHICLE', 'integer', 0, '', 0, 'current'],
@@ -543,19 +545,60 @@ class modDoliCar extends DolibarrModules
             dolibarr_set_const($this->db, 'DOLICAR_EXTRAFIELDS_BACKWARD_COMPATIBILITY', 1, 'integer', 0, '', $conf->entity);
         }
 
-        // Warehouse
-        if (getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID') <= 0) {
-            require_once DOL_DOCUMENT_ROOT . '/product/stock/class/entrepot.class.php';
+        // Warehouses
+        require_once DOL_DOCUMENT_ROOT . '/product/stock/class/entrepot.class.php';
+        require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+        require_once DOL_DOCUMENT_ROOT . '/product/class/productbatch.class.php';
+        require_once __DIR__ . '/../../../saturne/lib/object.lib.php';
 
-            $wareHouse = new Entrepot($this->db);
+        if (getDolGlobalInt('DOLICAR_INTERNE_WAREHOUSE_ID') <= 0) {
+            $oldWarehouseID = getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID');
 
-            $wareHouse->ref    = $langs->transnoentities('DoliCarWarehouse');
-            $wareHouse->label  = $langs->transnoentities('DoliCarWarehouse');
-            $wareHouse->statut = Entrepot::STATUS_OPEN_ALL;
+            $wareHouseInterne         = new Entrepot($this->db);
+            $wareHouseInterne->ref    = $langs->transnoentities('DoliCarInterneWarehouse');
+            $wareHouseInterne->label  = $langs->transnoentities('DoliCarInterneWarehouse');
+            $wareHouseInterne->statut = Entrepot::STATUS_OPEN_ALL;
+            $wareHouseInterneID       = $wareHouseInterne->create($user);
+            dolibarr_set_const($this->db, 'DOLICAR_INTERNE_WAREHOUSE_ID', $wareHouseInterneID, 'integer', 0, '', $conf->entity);
+            dolibarr_set_const($this->db, 'DOLICAR_DEFAULT_WAREHOUSE_ID', $wareHouseInterneID, 'integer', 0, '', $conf->entity);
 
-            $wareHouseID = $wareHouse->create($user);
+            if ($oldWarehouseID > 0 && $oldWarehouseID != $wareHouseInterneID) {
+                $productBatchHelper = new Productbatch($this->db);
+                $allProducts        = saturne_fetch_all_object_type('Product');
 
-            dolibarr_set_const($this->db, 'DOLICAR_DEFAULT_WAREHOUSE_ID', $wareHouseID, 'integer', 0, '', $conf->entity);
+                if (is_array($allProducts) && !empty($allProducts)) {
+                    foreach ($allProducts as $product) {
+                        $batches = $productBatchHelper->findAllForProduct($product->id, $oldWarehouseID, 0);
+                        if (is_array($batches) && !empty($batches)) {
+                            foreach ($batches as $batch) {
+                                $product->correct_stock_batch($user, $oldWarehouseID, $batch->qty, 1, 'Migration DoliCar', 0, '', '', $batch->batch);
+                                $product->correct_stock_batch($user, $wareHouseInterneID, $batch->qty, 0, 'Migration DoliCar', 0, '', '', $batch->batch);
+                            }
+                        } else {
+                            $product->load_stock();
+                            if (!empty($product->stock_warehouse[$oldWarehouseID]) && $product->stock_warehouse[$oldWarehouseID]->real > 0) {
+                                $qty = $product->stock_warehouse[$oldWarehouseID]->real;
+                                $product->correct_stock($user, $oldWarehouseID, $qty, 1, 'Migration DoliCar');
+                                $product->correct_stock($user, $wareHouseInterneID, $qty, 0, 'Migration DoliCar');
+                            }
+                        }
+                    }
+                }
+
+                $oldWarehouse = new Entrepot($this->db);
+                if ($oldWarehouse->fetch($oldWarehouseID) > 0) {
+                    $oldWarehouse->delete($user);
+                }
+            }
+        }
+
+        if (getDolGlobalInt('DOLICAR_REPARATION_WAREHOUSE_ID') <= 0) {
+            $wareHouseReparation         = new Entrepot($this->db);
+            $wareHouseReparation->ref    = $langs->transnoentities('DoliCarReparationWarehouse');
+            $wareHouseReparation->label  = $langs->transnoentities('DoliCarReparationWarehouse');
+            $wareHouseReparation->statut = Entrepot::STATUS_OPEN_ALL;
+            $wareHouseReparationID       = $wareHouseReparation->create($user);
+            dolibarr_set_const($this->db, 'DOLICAR_REPARATION_WAREHOUSE_ID', $wareHouseReparationID, 'integer', 0, '', $conf->entity);
         }
 
         require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';

--- a/core/modules/modDoliCar.class.php
+++ b/core/modules/modDoliCar.class.php
@@ -456,6 +456,22 @@ class modDoliCar extends DolibarrModules
             'target'   => '',
             'user'     => 0
         ];
+
+        $this->menu[$r++] = [
+            'fk_menu'  => 'fk_mainmenu=dolicar',
+            'type'     => 'left',
+            'titre'    => $langs->transnoentities('Tools'),
+            'prefix'   => '<i class="fas fa-wrench pictofixedwidth"></i>',
+            'mainmenu' => 'dolicar',
+            'leftmenu' => 'dolicartools',
+            'url'      => '/dolicar/view/dolicartools.php',
+            'langs'    => 'dolicar@dolicar',
+            'position' => 1000 + $r,
+            'enabled'  => '$conf->dolicar->enabled',
+            'perms'    => '$user->rights->dolicar->adminpage->read',
+            'target'   => '',
+            'user'     => 0
+        ];
     }
 
     /**

--- a/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
+++ b/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
@@ -96,11 +96,14 @@ if ($api == 'apiplaqueimmatriculation.com') {
         $productLot->batch      = $registrationCertificateObject->vin;
         $productLot->fk_product = $productId;
 
-        $productLotID = $productLot->create($user);
+        $productLotID    = $productLot->create($user);
+        $isNewProductLot = $productLotID > 0;
         if ($productLotID == -1) {
             $productLotID = $productLot->fetch(0, $productId, $registrationCertificateObject->vin);
         }
-        $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+        if ($isNewProductLot) {
+            $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+        }
 
         if ($productId > 0 && $productLotID > 0) {
 
@@ -246,11 +249,14 @@ if ($api == 'immatriculationapi.com') {
         $productLot->batch      = $registrationCertificateObject->ExtendedData->numSerieMoteur;
         $productLot->fk_product = $productId;
 
-        $productLotID = $productLot->create($user);
+        $productLotID    = $productLot->create($user);
+        $isNewProductLot = $productLotID > 0;
         if ($productLotID == -1) {
             $productLotID = $productLot->fetch(0, $productId, $registrationCertificateObject->vin);
         }
-        $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+        if ($isNewProductLot) {
+            $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+        }
 
         if ($productId > 0 && $productLotID > 0) {
             if (isset($createRegistrationCertificate) && $createRegistrationCertificate > 0) {

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -180,6 +180,18 @@ LicencePlateNotFoundInDB      = La plaque d'immatriculation est introuvable dans
 
 
 #
+# Tools - Outils
+#
+
+Tools                        = Outils
+FixLotStockQuantity          = Corriger les stocks de numéros de série
+FixLotStockQuantityWarning   = %s numéro(s) de série ont un stock supérieur à 1 (excédent total : %s pièce(s)). Ces lots seront ramenés à une quantité de 1.
+NoLotStockQuantityToFix      = Aucun numéro de série avec un stock supérieur à 1 détecté.
+Fix                          = Corriger
+FixLotStockQuantityLabel     = Correction du stock par l'outil DoliCar
+LotStockQuantityFixed        = %s numéro(s) de série corrigé(s) avec succès.
+
+#
 # Other
 #
 

--- a/view/dolicartools.php
+++ b/view/dolicartools.php
@@ -1,0 +1,194 @@
+<?php
+/* Copyright (C) 2024 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    view/dolicartools.php
+ * \ingroup dolicar
+ * \brief   Tools page for DoliCar
+ */
+
+// Load DoliCar environment
+if (file_exists('../dolicar.main.inc.php')) {
+    require_once __DIR__ . '/../dolicar.main.inc.php';
+} elseif (file_exists('../../dolicar.main.inc.php')) {
+    require_once __DIR__ . '/../../dolicar.main.inc.php';
+} else {
+    die('Include of dolicar main fails');
+}
+
+require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
+require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+
+global $conf, $db, $langs, $user;
+
+saturne_load_langs();
+
+$action = GETPOST('action', 'alpha');
+
+// Security check
+$permissiontoread = $user->rights->dolicar->adminpage->read;
+saturne_check_access($permissiontoread);
+
+/*
+ * Actions
+ */
+
+if ($action == 'fix_lot_stock_quantity') {
+    $product    = new Product($db);
+    $productLot = new ProductLot($db);
+    $errors     = [];
+    $fixed      = 0;
+
+    $sql  = 'SELECT pb.batch, pb.qty, ps.fk_product, ps.fk_entrepot';
+    $sql .= ' FROM ' . MAIN_DB_PREFIX . 'productbatch pb';
+    $sql .= ' JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock';
+    $sql .= ' JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.fk_product = ps.fk_product AND pl.batch = pb.batch';
+    $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'dolicar_registrationcertificatefr rc ON rc.fk_lot = pl.rowid';
+    $sql .= ' WHERE pb.qty > 1';
+
+    $resql = $db->query($sql);
+    if ($resql) {
+        while ($obj = $db->fetch_object($resql)) {
+            $result = $product->fetch($obj->fk_product);
+            if ($result > 0) {
+                $excess = $obj->qty - 1;
+                $result = $product->correct_stock_batch(
+                    $user,
+                    $obj->fk_entrepot,
+                    $excess,
+                    1,
+                    $langs->transnoentities('FixLotStockQuantityLabel'),
+                    0,
+                    '',
+                    '',
+                    $obj->batch,
+                    '',
+                    'dolicar_registrationcertificate',
+                    0
+                );
+                if ($result > 0) {
+                    $fixed++;
+                } else {
+                    $errors[] = $product->error;
+                }
+            }
+        }
+        $db->free($resql);
+    } else {
+        $errors[] = $db->lasterror();
+    }
+
+    if (!empty($errors)) {
+        setEventMessages('', $errors, 'errors');
+    } else {
+        setEventMessages($langs->transnoentities('LotStockQuantityFixed', $fixed), [], 'mesgs');
+    }
+
+    header('Location: ' . $_SERVER['PHP_SELF']);
+    exit;
+}
+
+/*
+ * View
+ */
+
+$title = $langs->trans('Tools');
+
+saturne_header(0, '', $title);
+
+print load_fiche_titre($title, '', 'wrench');
+
+// Section: fix lot stock quantity > 1
+print load_fiche_titre($langs->trans('FixLotStockQuantity'), '', '');
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->trans('Name') . '</td>';
+print '<td>' . $langs->trans('Description') . '</td>';
+print '<td class="center">' . $langs->trans('Action') . '</td>';
+print '</tr>';
+
+// Count affected lots
+$sql  = 'SELECT COUNT(*) as nb, SUM(pb.qty - 1) as excess';
+$sql .= ' FROM ' . MAIN_DB_PREFIX . 'productbatch pb';
+$sql .= ' JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock';
+$sql .= ' JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.fk_product = ps.fk_product AND pl.batch = pb.batch';
+$sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'dolicar_registrationcertificatefr rc ON rc.fk_lot = pl.rowid';
+$sql .= ' WHERE pb.qty > 1';
+
+$resql   = $db->query($sql);
+$nbLots  = 0;
+$excess  = 0;
+if ($resql) {
+    $obj    = $db->fetch_object($resql);
+    $nbLots = (int)$obj->nb;
+    $excess = (int)$obj->excess;
+    $db->free($resql);
+}
+
+print '<form name="fix_lot_stock_quantity" action="' . $_SERVER['PHP_SELF'] . '" method="POST">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<input type="hidden" name="action" value="fix_lot_stock_quantity">';
+
+print '<tr class="oddeven"><td>';
+print $langs->trans('FixLotStockQuantity');
+print '</td><td>';
+print '<div class="wpeo-notice ' . ($nbLots > 0 ? 'notice-warning' : 'notice-success') . '">';
+print '<div class="notice-content">';
+
+if ($nbLots > 0) {
+    // Detailed list of affected lots
+    $sqlDetail  = 'SELECT pb.batch, pb.qty, p.ref as product_ref, p.label as product_label';
+    $sqlDetail .= ' FROM ' . MAIN_DB_PREFIX . 'productbatch pb';
+    $sqlDetail .= ' JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock';
+    $sqlDetail .= ' JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.fk_product = ps.fk_product AND pl.batch = pb.batch';
+    $sqlDetail .= ' JOIN ' . MAIN_DB_PREFIX . 'product p ON p.rowid = ps.fk_product';
+    $sqlDetail .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'dolicar_registrationcertificatefr rc ON rc.fk_lot = pl.rowid';
+    $sqlDetail .= ' WHERE pb.qty > 1';
+    $sqlDetail .= ' ORDER BY p.ref';
+
+    $resqlDetail = $db->query($sqlDetail);
+
+    print '<div class="notice-subtitle"><strong>' . $langs->transnoentities('FixLotStockQuantityWarning', $nbLots, $excess) . '</strong></div>';
+    print '<br>';
+    print '<table class="nobordernopadding">';
+    print '<tr><th>' . $langs->trans('Batch') . '</th><th style="padding-left:20px">' . $langs->trans('Product') . '</th><th style="padding-left:20px">' . $langs->trans('Qty') . '</th></tr>';
+    if ($resqlDetail) {
+        while ($obj = $db->fetch_object($resqlDetail)) {
+            print '<tr>';
+            print '<td>' . dol_escape_htmltag($obj->batch) . '</td>';
+            print '<td style="padding-left:20px">' . dol_escape_htmltag($obj->product_ref) . ' – ' . dol_escape_htmltag($obj->product_label) . '</td>';
+            print '<td style="padding-left:20px"><strong>' . $obj->qty . '</strong></td>';
+            print '</tr>';
+        }
+        $db->free($resqlDetail);
+    }
+    print '</table>';
+} else {
+    print '<div class="notice-subtitle"><strong>' . $langs->trans('NoLotStockQuantityToFix') . '</strong></div>';
+}
+
+print '</div></div>';
+print '</td><td class="center">';
+print '<input type="submit" class="button reposition wpeo-button button-load ' . ($nbLots == 0 ? 'button-disable' : '') . '" value="' . $langs->trans('Fix') . '"' . ($nbLots == 0 ? ' disabled' : '') . '>';
+print '</td></tr>';
+print '</form>';
+
+print '</table>';
+
+llxFooter();
+$db->close();

--- a/view/dolicartools.php
+++ b/view/dolicartools.php
@@ -147,12 +147,12 @@ print '<input type="hidden" name="action" value="fix_lot_stock_quantity">';
 print '<tr class="oddeven"><td>';
 print $langs->trans('FixLotStockQuantity');
 print '</td><td>';
-print '<div class="wpeo-notice ' . ($nbLots > 0 ? 'notice-warning' : 'notice-success') . '">';
+print '<div class="wpeo-notice ' . ($nbLots > 0 ? 'notice-warning' : 'notice-success') . '" style="' . ($nbLots > 0 ? 'display:block' : '') . '">';
 print '<div class="notice-content">';
 
 if ($nbLots > 0) {
-    // Detailed list of affected lots
-    $sqlDetail  = 'SELECT pb.batch, pb.qty, p.ref as product_ref, p.label as product_label';
+    $sqlDetail  = 'SELECT pb.batch, pb.qty, p.ref as product_ref, p.label as product_label,';
+    $sqlDetail .= ' rc.rowid as rc_id, rc.ref as rc_ref, rc.a_registration_number';
     $sqlDetail .= ' FROM ' . MAIN_DB_PREFIX . 'productbatch pb';
     $sqlDetail .= ' JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock';
     $sqlDetail .= ' JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.fk_product = ps.fk_product AND pl.batch = pb.batch';
@@ -163,16 +163,27 @@ if ($nbLots > 0) {
 
     $resqlDetail = $db->query($sqlDetail);
 
+    $rcCardUrl = dol_buildpath('/custom/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1);
+
     print '<div class="notice-subtitle"><strong>' . $langs->transnoentities('FixLotStockQuantityWarning', $nbLots, $excess) . '</strong></div>';
     print '<br>';
-    print '<table class="nobordernopadding">';
-    print '<tr><th>' . $langs->trans('Batch') . '</th><th style="padding-left:20px">' . $langs->trans('Product') . '</th><th style="padding-left:20px">' . $langs->trans('Qty') . '</th></tr>';
+    print '<table class="noborder" style="width:100%">';
+    print '<tr class="liste_titre">';
+    print '<td>' . $langs->trans('RegistrationCertificateFr') . '</td>';
+    print '<td>' . $langs->trans('RegistrationNumber') . '</td>';
+    print '<td>' . $langs->trans('DolicarBatch') . '</td>';
+    print '<td>' . $langs->trans('Product') . '</td>';
+    print '<td class="center">' . $langs->trans('Qty') . '</td>';
+    print '</tr>';
     if ($resqlDetail) {
         while ($obj = $db->fetch_object($resqlDetail)) {
-            print '<tr>';
+            $rcLink = '<a href="' . $rcCardUrl . '?id=' . $obj->rc_id . '">' . dol_escape_htmltag($obj->rc_ref) . '</a>';
+            print '<tr class="oddeven">';
+            print '<td>' . $rcLink . '</td>';
+            print '<td>' . dol_escape_htmltag($obj->a_registration_number) . '</td>';
             print '<td>' . dol_escape_htmltag($obj->batch) . '</td>';
-            print '<td style="padding-left:20px">' . dol_escape_htmltag($obj->product_ref) . ' – ' . dol_escape_htmltag($obj->product_label) . '</td>';
-            print '<td style="padding-left:20px"><strong>' . $obj->qty . '</strong></td>';
+            print '<td>' . dol_escape_htmltag($obj->product_ref) . ' – ' . dol_escape_htmltag($obj->product_label) . '</td>';
+            print '<td class="center"><strong style="color:var(--colorbacktitle2,#e05d2c)">' . $obj->qty . '</strong></td>';
             print '</tr>';
         }
         $db->free($resqlDetail);

--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -37,6 +37,8 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/html.formprojet.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
+require_once DOL_DOCUMENT_ROOT . '/core/class/html.form.class.php';
+require_once DOL_DOCUMENT_ROOT . '/product/class/html.formproduct.class.php';
 
 // Load DoliCar libraries
 require_once __DIR__ . '/../../class/registrationcertificatefr.class.php';
@@ -229,6 +231,17 @@ if ($action == 'create') {
 
     // Common attributes
     require_once DOL_DOCUMENT_ROOT . '/core/tpl/commonfields_add.tpl.php';
+
+    // Warehouse
+    print '<tr>';
+    print '<td class="titlefieldcreate">';
+    print $langs->trans('WarehouseForThisVehicle');
+    print '</td>';
+    print '<td class="valuefieldcreate">';
+    $formproduct = new FormProduct($db);
+    print $formproduct->selectWarehouses(GETPOSTINT('warehouse_id') > 0 ? GETPOSTINT('warehouse_id') : getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 'warehouse_id', '', 1, 0, 0, '', 0, 0, [], 'minwidth300');
+    print '</td>';
+    print '</tr>';
 
     // Other attributes
     require_once DOL_DOCUMENT_ROOT . '/core/tpl/extrafields_add.tpl.php';


### PR DESCRIPTION
## Changements
- Ajout du flag isNewProductLot pour detecter si le lot VIN vient d'etre cree ou existait deja
- correct_stock_batch() conditionne a la creation effective du lot uniquement
- Fix applique sur les deux blocs API : apiplaqueimmatriculation.com et immatriculationapi.com

## Fichiers modifies
- core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php

## Cause
Lors d'un appel API avec un VIN deja existant, productLot->create() retournait -1, mais correct_stock_batch() etait appele inconditionnellement, incrementant le stock de +1 a chaque appel.

## Issue
#374