### PR TITLE
#377 [LinkedObjects] fix: hide deleted controls in linked objects list

### DIFF
--- a/core/tpl/registrationcertificatefr_linked_objects.tpl.php
+++ b/core/tpl/registrationcertificatefr_linked_objects.tpl.php
@@ -116,6 +116,9 @@ $registrationCertificate->fetchObjectLinked();
 if (!empty($registrationCertificate->linkedObjects)) {
     foreach ($registrationCertificate->linkedObjects as $linkedObjectElement => $linkedObjects) {
         foreach ($linkedObjects as $linkedObjectId => $linkedObject) {
+            if (isset($linkedObject->status) && $linkedObject->status == -1) {
+                continue;
+            }
             $rows[$linkedObjectElement . '_' . $linkedObjectId] = $renderLinkedObjectRow($linkedObject, $linkedObjectElement, $digiqualiEnabled, $langs);
         }
     }
@@ -130,6 +133,9 @@ if ($digiqualiEnabled && $registrationCertificate->fk_lot > 0) {
     foreach (['digiquali_control', 'digiquali_survey'] as $elementType) {
         if (!empty($productLotLinked->linkedObjects[$elementType])) {
             foreach ($productLotLinked->linkedObjects[$elementType] as $linkedObjectId => $linkedObject) {
+                if (isset($linkedObject->status) && $linkedObject->status == -1) {
+                    continue;
+                }
                 $key = $elementType . '_' . $linkedObjectId;
                 if (!isset($rows[$key])) {
                     $rows[$key] = $renderLinkedObjectRow($linkedObject, $elementType, $digiqualiEnabled, $langs);


### PR DESCRIPTION
## Changements
- Ajout d un filtre sur le statut dans les deux boucles d iteration des objets lies
- Les controles avec status = -1 (supprime) sont desormais ignores lors de la construction du tableau des objets lies
- Correction appliquee a la fois sur les liens directs de la carte grise et sur les liens via le lot produit associe

## Fichiers modifies
- core/tpl/registrationcertificatefr_linked_objects.tpl.php

## Issue
#377