### PR TITLE
#374 [RegistrationCertificate] fix: use selected warehouse_id on stock batch creation

### DIFF
--- a/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
+++ b/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
@@ -102,7 +102,7 @@ if ($api == 'apiplaqueimmatriculation.com') {
             $productLotID = $productLot->fetch(0, $productId, $registrationCertificateObject->vin);
         }
         if ($isNewProductLot) {
-            $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+            $product->correct_stock_batch($user, GETPOSTINT('warehouse_id') > 0 ? GETPOSTINT('warehouse_id') : getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
         }
 
         if ($productId > 0 && $productLotID > 0) {
@@ -255,7 +255,7 @@ if ($api == 'immatriculationapi.com') {
             $productLotID = $productLot->fetch(0, $productId, $registrationCertificateObject->vin);
         }
         if ($isNewProductLot) {
-            $product->correct_stock_batch($user, getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
+            $product->correct_stock_batch($user, GETPOSTINT('warehouse_id') > 0 ? GETPOSTINT('warehouse_id') : getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 1, 0, $langs->transnoentities('ClientVehicle'), 0, '', '', $productLot->batch, '', 'dolicar_registrationcertificate', 0);
         }
 
         if ($productId > 0 && $productLotID > 0) {

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -23,7 +23,9 @@ DoliCarDescription = Gestion et réparations d'un parc automobile
 
 # Init - Initialisation
 DefaultBrand     = Marque par défaut
-DoliCarWarehouse = Entrepôt de DoliCar
+DoliCarWarehouse           = Entrepôt de DoliCar
+DoliCarInterneWarehouse    = Dolicar Interne
+DoliCarReparationWarehouse = Dolicar Reparation
 ClientVehicle    = Véhicule client
 DefaultVehicle   = Véhicule par défaut
 
@@ -72,8 +74,12 @@ MaxArrivalMileage            = Nombre maximal de kilomètre d'arrivé
 MaxArrivalMileageDescription = Cette option permet de configurer le nombre maximal de kilomètre d'arrivé qu'un conducteur peut saisir lors de l'enregistrement d'une donné dans le carnet de bord d'un véhicule <br> (par défaut 1000 km)
 
 # Setup - Réglages
-ImmatriculationAPIConfig = Configuration de l'API
-RemainingRequests        = Jetons de recherche de plaque d'immatriculation restants : %s
+ImmatriculationAPIConfig          = Configuration de l'API
+RemainingRequests                 = Jetons de recherche de plaque d'immatriculation restants : %s
+WarehouseConfig                   = Configuration des entrepôts
+DefaultWarehouseForVehicle        = Entrepôt par défaut pour la création de véhicule
+DefaultWarehouseForVehicleDesc    = Entrepôt dans lequel les véhicules sont créés par défaut (modifiable lors de la création d'une carte grise)
+WarehouseForThisVehicle           = Entrepôt de destination
 
 
 


### PR DESCRIPTION
## Changements
- Correction de l appel correct_stock_batch pour les deux APIs (apiplaqueimmatriculation.com et immatriculationapi.com)
- Le stock est desormais incremente dans l entrepot selectionne par l utilisateur (warehouse_id en POST) au lieu de toujours utiliser l entrepot par defaut
- Ajout des cles de traduction pour la configuration des entrepots (WarehouseConfig, DefaultWarehouseForVehicle, WarehouseForThisVehicle)

## Fichiers modifies
- core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
- langs/fr_FR/dolicar.lang

## Issue
#374