### PR TITLE
#383 [RegistrationCertificateFr] fix: initialize Categorie object to prevent fatal error on fetch

### DIFF
--- a/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
+++ b/core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php
@@ -232,7 +232,7 @@ if ($api == 'immatriculationapi.com') {
             $productId = $product->create($user);
             if ($productId > 0) {
                 $resultCategory = $category->fetch(0, $registrationCertificateObject->CarMake->CurrentTextValue);
-                if ($category <= 0) {
+                if ($category->id <= 0) {
                     $category->label       = $registrationCertificateObject->CarMake->CurrentTextValue;
                     $category->description = $registrationCertificateObject->CarMake->CurrentTextValue;
                     $category->visible     = 1;

--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -34,6 +34,7 @@ if (file_exists('../dolicar.main.inc.php')) {
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formcompany.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formprojet.class.php';
+require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
 require_once DOL_DOCUMENT_ROOT . '/core/lib/date.lib.php';
@@ -64,6 +65,7 @@ $fromid              = GETPOSTINT('fromid');
 
 // Initialize technical objects
 $object      = new RegistrationCertificateFr($db);
+$category    = new Categorie($db);
 $product     = new Product($db);
 $productLot  = new Productlot($db);
 $extrafields = new ExtraFields($db);


### PR DESCRIPTION
## Changements
- Ajout du require_once pour categorie.class.php dans registrationcertificatefr_card.php
- Instanciation de $category = new Categorie($db) avant l'include du template
- Correction de la comparaison $category <= 0 en $category->id <= 0 dans le bloc immatriculationapi.com

## Fichiers modifies
- view/registrationcertificatefr/registrationcertificatefr_card.php
- core/tpl/dolicar_registrationcertificatefr_immatriculation_api_fetch_action.tpl.php

## Issue
#383