### PR TITLE
#380 [Admin] fix: load admin lang domain for missing translations

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -41,7 +41,7 @@ require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
 global $conf, $db, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs();
+saturne_load_langs(['admin']);
 
 // Security check - Protection if external user
 $permissionToRead = $user->rights->dolicar->adminpage->read;


### PR DESCRIPTION
## Changements
- Ajout du domaine `admin` dans `saturne_load_langs()` de la page de configuration
- Permet de résoudre les traductions manquantes provenant de `admin.lang` (ex: `SetupSaved`)
- Utilise la traduction native Dolibarr sans duplication dans les fichiers de traduction dolicar

## Fichiers modifiés
- `admin/setup.php`

## Issue
#380
