### PR TITLE
#395 [RegistrationCertificateFr] rework: replace file_get_contents with curl for immatriculationapi

### DIFF
--- a/class/registrationcertificatefr.class.php
+++ b/class/registrationcertificatefr.class.php
@@ -468,7 +468,6 @@ class RegistrationCertificateFr extends SaturneObject
             $response = curl_exec($curl);
             curl_close($curl);
 
-
             $registrationCertificateObjectJson = json_decode($response);
 
             if (isset($registrationCertificateObjectJson->code_erreur) && $registrationCertificateObjectJson->code_erreur != 200) {
@@ -490,16 +489,36 @@ class RegistrationCertificateFr extends SaturneObject
             $apiUrl   = 'https://www.immatriculationapi.com/api/reg.asmx/CheckFrance';
 
             if (dol_strlen($username) > 0) {
-                dol_syslog($apiUrl . '?RegistrationNumber=' . $searchValue . '&username=' . $username, LOG_ERR);
-                $xmlData = @file_get_contents( $apiUrl . '?RegistrationNumber=' . $searchValue . '&username=' . $username);
-                dol_syslog($xmlData, LOG_ERR);
-                if (empty($xmlData)) {
-                    setEventMessages($langs->trans('BadAPIUsernameOrBadLicencePlateFormat'), [], 'errors');
+                $curl = curl_init();
+                curl_setopt_array($curl, [
+                    CURLOPT_URL            => $apiUrl . '?RegistrationNumber=' . urlencode($searchValue) . '&username=' . urlencode($username),
+                    CURLOPT_RETURNTRANSFER => true,
+                    CURLOPT_SSL_VERIFYPEER => false,
+                    CURLOPT_USERAGENT      => $this->module . '-Agent/' . DOL_VERSION,
+                    CURLOPT_CONNECTTIMEOUT => 5,
+                    CURLOPT_TIMEOUT        => 0,
+                    CURLOPT_FOLLOWLOCATION => true,
+                    CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
+                    CURLOPT_CUSTOMREQUEST  => 'GET',
+                ]);
+                $xmlData   = curl_exec($curl);
+                $httpCode  = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+                $curlError = curl_error($curl);
+                curl_close($curl);
+
+                if (empty($xmlData) || !empty($curlError)) {
+                    setEventMessages($langs->trans('BadAPIUsernameOrBadLicencePlateFormat', $curlError), [], 'errors');
                     header('Location: ' . $_SERVER['PHP_SELF'] . '?action=create&a_registration_number=' . GETPOST('registrationNumber'));
                     exit;
                 } else {
-                    $xml     = simplexml_load_string($xmlData);
-                    $strJson = $xml->vehicleJson;
+                    $xml = @simplexml_load_string($xmlData);
+                    if ($xml === false || !isset($xml->vehicleJson)) {
+                        dol_syslog(__METHOD__ . ' immatriculationapi.com: unexpected response (not XML or missing vehicleJson): ' . $xmlData, LOG_ERR);
+                        setEventMessages($langs->trans('BadAPIUsernameOrBadLicencePlateFormat', $xmlData), [], 'errors');
+                        header('Location: ' . $_SERVER['PHP_SELF'] . '?action=create&a_registration_number=' . GETPOST('registrationNumber'));
+                        exit;
+                    }
+                    $strJson = (string) $xml->vehicleJson;
                     $registrationCertificateObject = json_decode($strJson);
                     dolibarr_set_const($db, 'DOLICAR_API_REMAINING_REQUESTS_COUNTER', getDolGlobalString('DOLICAR_API_REMAINING_REQUESTS_COUNTER') - 1, 'integer', 0, '', $conf->entity);
                     dolibarr_set_const($db, 'DOLICAR_API_REQUESTS_COUNTER', getDolGlobalString('DOLICAR_API_REMAINING_REQUESTS_COUNTER') + 1, 'integer', 0, '', $conf->entity);

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -156,7 +156,7 @@ LinkedProductBatch = Numéro de lot/série lié
 ZeroApiRequestsRemaining              = Vous n'avez plus de jetons de recherche de plaque d'immatriculation. Pour en obtenir à nouveau, contactez votre administrateur.
 LessThanHundredApiRequestsRemaining   = Il vous reste moins de 10 jetons de recherche de plaque d'immatriculation. Pour en obtenir à nouveau, contactez votre administrateur.
 LicencePlateWasAlreadyExisting        = La plaque d'immatriculation existe déjà, vous avez été redirigé(e) sur sa page.
-BadAPIUsernameOrBadLicencePlateFormat = Mauvais nom d'utilisateur ou format de plaque d'immatriculation. <br> Veuillez utiliser l'un des formats suivants pour la plaque d'immatriculation : <br><b> XX-111-XX <br>  XX111XX </b>
+BadAPIUsernameOrBadLicencePlateFormat = Erreur (<strong> %s </strong>) <br> Mauvais nom d'utilisateur ou format de plaque d'immatriculation. <br> Veuillez utiliser l'un des formats suivants pour la plaque d'immatriculation : <br><b> XX-111-XX <br>  XX111XX </b>
 LicencePlateInformationsCharged       = Les informations de la carte grise ont bien été récupérées
 BadAPIUsername                        = Nom d'utilisateur pour l'API invalide
 


### PR DESCRIPTION
## Changements
- Remplacement de file_get_contents par curl pour l'appel API immatriculationapi.com, aligne sur le meme style que apiplaqueimmatriculation.com
- Ajout de la capture du code HTTP (CURLINFO_HTTP_CODE) et des erreurs curl
- Gestion robuste de la reponse : verification que simplexml_load_string reussit et que vehicleJson est present avant de continuer
- Ajout d'un dol_syslog en cas de reponse inattendue (non-XML ou champ manquant)
- Mise a jour de la traduction BadAPIUsernameOrBadLicencePlateFormat pour afficher le detail de l'erreur recue

## Fichiers modifies
- class/registrationcertificatefr.class.php
- langs/fr_FR/dolicar.lang

## Issue
#395