### PR TITLE
#393 [Admin] fix: read action parameter so all/none buttons work

### DIFF
--- a/admin/quickcreation.php
+++ b/admin/quickcreation.php
@@ -39,6 +39,9 @@ global $conf, $db, $langs, $moduleNameLowerCase, $user;
 // Load translation files required by the page
 saturne_load_langs();
 
+// Get parameters
+$action = GETPOST('action', 'alpha');
+
 // Security check - Protection if external user
 $permissionToRead = $user->rights->dolicar->adminpage->read && isModEnabled('reedcrm');
 saturne_check_access($permissionToRead);


### PR DESCRIPTION
## Changements
- Ajout de la lecture du parametre action via GETPOST dans admin/quickcreation.php
- Sans cette ligne, $action etait toujours vide et les conditions add_all_conf / delete_all_conf dans le template object_const_view.tpl.php n'etaient jamais verifiees
- Les boutons TOUT et Aucun fonctionnent desormais correctement

## Fichiers modifies
- admin/quickcreation.php

## Issue
#393