### PR TITLE
#388 [RegistrationCertificateFr] feat: group carte grise fields with collapsible section

### DIFF
--- a/css/scss/element/_element.scss
+++ b/css/scss/element/_element.scss
@@ -1,1 +1,1 @@
-@import "form";
+@use "form";

--- a/css/scss/pages/_pages.scss
+++ b/css/scss/pages/_pages.scss
@@ -1,1 +1,2 @@
-@import "vehicle-logbook";
+@use "vehicle-logbook";
+@use "registrationcertificatefr-card";

--- a/css/scss/pages/_registrationcertificatefr-card.scss
+++ b/css/scss/pages/_registrationcertificatefr-card.scss
@@ -1,0 +1,31 @@
+.tableforfield,
+.tableforfieldcreate,
+.tableforfieldedit {
+    .registration-certificate-group-header {
+        cursor: pointer;
+        user-select: none;
+
+        td {
+            background: var(--colorbacktitle1) !important;
+            font-weight: bold !important;
+            padding: 5px 10px !important;
+            border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
+        }
+
+        &:hover td {
+            filter: brightness(0.95) !important;
+        }
+
+        .registration-certificate-group-icon {
+            margin-right: 10px;
+            display: inline-block;
+            width: 10px;
+        }
+    }
+
+    .registration-certificate-field {
+        td:first-child {
+            padding-left: 18px !important;
+        }
+    }
+}

--- a/css/scss/style.scss
+++ b/css/scss/style.scss
@@ -1,5 +1,5 @@
-@import "element/element";
-@import "pages/pages";
+@use "element/element";
+@use "pages/pages";
 
 .product-object .nowraponall {
   white-space: normal;

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -88,6 +88,7 @@ WarehouseForThisVehicle           = Entrepôt de destination
 #
 
 # Data - Donnée
+RegistrationCertificateData     = Données de la carte grise
 RegistrationCertificateFr       = Carte grise
 Registrationcertificatefrs      = Cartes grises
 Registrationcertificatefr       = Carte grise

--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -145,6 +145,13 @@ if (empty($resHook)) {
 $title   = $langs->trans(ucfirst($object->element));
 $helpUrl = 'FR:Module_DoliCar';
 
+$configFields     = array_keys(array_filter($object->fields, static function ($field) {
+    return !empty($field['config']);
+}));
+$configFieldsJson = json_encode(array_map(static function ($f) {
+    return 'field_' . $f;
+}, $configFields));
+
 saturne_header( 0, '', $title, $helpUrl);
 
 // Part to create
@@ -258,11 +265,37 @@ if ($action == 'create') {
     print '</form>'; ?>
 
     <script>
-        const $table     = $('.tableforfieldcreate');
-        const $rowToMove = $table.find('.field_fk_lot');
-        const $targetRow = $table.find('.field_fk_product');
+        const $createTable = $('.tableforfieldcreate');
+        const $rowToMove   = $createTable.find('.field_fk_lot');
+        const $targetRow   = $createTable.find('.field_fk_product');
 
         $targetRow.after($rowToMove);
+
+        const registrationCertificateCreateConfigFields = <?= $configFieldsJson ?>;
+        let $registrationCertificateCreateFirstRow      = null;
+        let $registrationCertificateCreateGroupRows     = $();
+
+        $.each(registrationCertificateCreateConfigFields, function (index, fieldClass) {
+            const $row = $createTable.find('tr.' + fieldClass);
+            if ($row.length > 0) {
+                $registrationCertificateCreateGroupRows = $registrationCertificateCreateGroupRows.add($row);
+                if ($registrationCertificateCreateFirstRow === null) {
+                    $registrationCertificateCreateFirstRow = $row;
+                }
+            }
+        });
+
+        if ($registrationCertificateCreateGroupRows.length > 0) {
+            $registrationCertificateCreateGroupRows.hide();
+
+            const $createGroupHeader = $('<tr class="registration-certificate-group-header"><td colspan="2"><i class="fas fa-chevron-right registration-certificate-group-icon"></i><?= dol_escape_htmltag($langs->trans('RegistrationCertificateData')) ?></td></tr>');
+            $registrationCertificateCreateFirstRow.before($createGroupHeader);
+
+            $createTable.on('click', '.registration-certificate-group-header', function () {
+                $registrationCertificateCreateGroupRows.toggle();
+                $(this).find('.registration-certificate-group-icon').toggleClass('fa-chevron-down fa-chevron-right');
+            });
+        }
     </script>
     <?php
 }
@@ -316,11 +349,37 @@ if (($id || $ref) && $action == 'edit') {
     print '</form>'; ?>
 
     <script>
-        const $table     = $('.tableforfieldedit');
-        const $rowToMove = $table.find('.field_fk_lot');
-        const $targetRow = $table.find('.field_fk_product');
+        const $editTable     = $('.tableforfieldedit');
+        const $editRowToMove = $editTable.find('.field_fk_lot');
+        const $editTargetRow = $editTable.find('.field_fk_product');
 
-        $targetRow.after($rowToMove);
+        $editTargetRow.after($editRowToMove);
+
+        const registrationCertificateEditConfigFields = <?= $configFieldsJson ?>;
+        let $registrationCertificateEditFirstRow      = null;
+        let $registrationCertificateEditGroupRows     = $();
+
+        $.each(registrationCertificateEditConfigFields, function (index, fieldClass) {
+            const $row = $editTable.find('tr.' + fieldClass);
+            if ($row.length > 0) {
+                $registrationCertificateEditGroupRows = $registrationCertificateEditGroupRows.add($row);
+                if ($registrationCertificateEditFirstRow === null) {
+                    $registrationCertificateEditFirstRow = $row;
+                }
+            }
+        });
+
+        if ($registrationCertificateEditGroupRows.length > 0) {
+            $registrationCertificateEditGroupRows.hide();
+
+            const $editGroupHeader = $('<tr class="registration-certificate-group-header"><td colspan="2"><i class="fas fa-chevron-right registration-certificate-group-icon"></i><?= dol_escape_htmltag($langs->trans('RegistrationCertificateData')) ?></td></tr>');
+            $registrationCertificateEditFirstRow.before($editGroupHeader);
+
+            $editTable.on('click', '.registration-certificate-group-header', function () {
+                $registrationCertificateEditGroupRows.toggle();
+                $(this).find('.registration-certificate-group-icon').toggleClass('fa-chevron-down fa-chevron-right');
+            });
+        }
     </script>
     <?php
 }
@@ -360,6 +419,41 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
     print '</table>';
     print '</div>';
     print '</div>';
+
+    ?>
+
+    <script>
+        const $registrationCertificateTable = $('.tableforfield');
+
+        if ($registrationCertificateTable.length > 0) {
+            const registrationCertificateConfigFields = <?= $configFieldsJson ?>;
+            let $registrationCertificateFirstRow      = null;
+            let $registrationCertificateGroupRows     = $();
+
+            $.each(registrationCertificateConfigFields, function (index, fieldClass) {
+                const $row = $registrationCertificateTable.find('tr.' + fieldClass);
+                if ($row.length > 0) {
+                    $registrationCertificateGroupRows = $registrationCertificateGroupRows.add($row);
+                    if ($registrationCertificateFirstRow === null) {
+                        $registrationCertificateFirstRow = $row;
+                    }
+                }
+            });
+
+            if ($registrationCertificateGroupRows.length > 0) {
+                $registrationCertificateGroupRows.addClass('registration-certificate-field').hide();
+
+                const $groupHeader = $('<tr class="registration-certificate-group-header"><td colspan="2"><i class="fas fa-chevron-right registration-certificate-group-icon"></i><?= dol_escape_htmltag($langs->trans('RegistrationCertificateData')) ?></td></tr>');
+                $registrationCertificateFirstRow.before($groupHeader);
+
+                $registrationCertificateTable.on('click', '.registration-certificate-group-header', function () {
+                    $registrationCertificateGroupRows.toggle();
+                    $(this).find('.registration-certificate-group-icon').toggleClass('fa-chevron-down fa-chevron-right');
+                });
+            }
+        }
+    </script>
+    <?php
 
     print '<div class="clearboth"></div>';
 


### PR DESCRIPTION
#388

## Changements
- Regroupement collapsible des champs carte grise (config = 1) dans les vues create, edit et view
- Champs masques par defaut, affiches au clic sur l'en-tete Donnees de la carte grise
- Style via var(--colorbacktitle1) pour integration native au theme Dolibarr
- Ajout cle de traduction RegistrationCertificateData
- Nouveau partial SCSS _registrationcertificatefr-card.scss
- Migration @import vers @use (Dart Sass 3.0 deprecation)

## Fichiers modifies
- view/registrationcertificatefr/registrationcertificatefr_card.php
- langs/fr_FR/dolicar.lang
- css/scss/pages/_registrationcertificatefr-card.scss (nouveau)
- css/scss/pages/_pages.scss
- css/scss/element/_element.scss
- css/scss/style.scss