### PR TITLE
#389 [Dashboard] feat: add warehouse stats, recent activities and overdue CT widgets

### DIFF
--- a/class/dolicardashboard.class.php
+++ b/class/dolicardashboard.class.php
@@ -17,7 +17,7 @@
 
 /**
  * \file    class/dolicardashboard.class.php
- * \ingroup digiquali
+ * \ingroup dolicar
  * \brief   Class file for manage DolicarDashboard
  */
 
@@ -49,23 +49,398 @@ class DolicarDashboard
      */
     public function load_dashboard(): array
     {
-        global $langs;
+        $array = ['dolicar' => ['widgets' => [], 'graphs' => [], 'lists' => []]];
 
-        $array = ['dolicar' => ['widgets' => [], 'graphs' => []]];
+        $interneWarehouseID    = getDolGlobalInt('DOLICAR_INTERNE_WAREHOUSE_ID');
+        $reparationWarehouseID = getDolGlobalInt('DOLICAR_REPARATION_WAREHOUSE_ID');
 
-        $regestrationCertifatesFr         = saturne_fetch_all_object_type('registrationcertificatefr', '', '', 0, 0, [], 'AND', true, true, false, '');
-        $numberOfRegestrationCertifatesFr = count($regestrationCertifatesFr);
+        $array['dolicar']['widgets']['warehouseStats'] = $this->loadWarehouseWidget($interneWarehouseID, $reparationWarehouseID);
 
-        $array['dolicar']['graphs'][] = RegistrationCertificateFr::load_dashboard($regestrationCertifatesFr);
+        $array['dolicar']['lists']['overdueCtList']    = $this->loadOverdueCTList();
 
-        $array['dolicar']['widgets']['informations'] = [
-            'title'      => $langs->transnoentities('Informations'),
-            'picto'      => 'fas fa-car',
-            'label'      => [$langs->transnoentities('DashboardNumberOfRegestrationCertifatesFr'), $langs->transnoentities('DashboardRemainingRequestsRequest')],
-            'content'    => [$numberOfRegestrationCertifatesFr, getDolGlobalInt('DOLICAR_API_REMAINING_REQUESTS_COUNTER')],
-            'widgetName' => 'informations'
-        ];
+        $warehouseList = $this->loadWarehouseList($interneWarehouseID, $reparationWarehouseID);
+        if (!empty($warehouseList)) {
+            $array['dolicar']['lists']['warehouseList'] = $warehouseList;
+        }
+
+        $array['dolicar']['lists']['recentActivities'] = $this->loadRecentActivitiesList();
 
         return $array;
+    }
+
+    /**
+     * Build the warehouse stats widget data
+     *
+     * @param  int   $interneWarehouseID    ID of the internal warehouse
+     * @param  int   $reparationWarehouseID ID of the repair warehouse
+     * @return array                        Widget data array
+     */
+    private function loadWarehouseWidget(int $interneWarehouseID, int $reparationWarehouseID): array
+    {
+        global $langs;
+
+        $warehouseCounts = $this->getWarehouseCounts($interneWarehouseID, $reparationWarehouseID);
+        $interneCount    = $warehouseCounts[$interneWarehouseID] ?? 0;
+        $reparationCount = $warehouseCounts[$reparationWarehouseID] ?? 0;
+
+        $listUrl = dol_buildpath('/dolicar/view/registrationcertificatefr/registrationcertificatefr_list.php', 1);
+
+        return [
+            'title'      => $langs->transnoentities('DashboardWarehouseStats'),
+            'picto'      => 'fas fa-warehouse',
+            'label'      => [
+                $langs->transnoentities('DoliCarInterneWarehouse'),
+                $langs->transnoentities('DoliCarReparationWarehouse'),
+            ],
+            'content'    => [
+                '<a href="' . $listUrl . '">' . $interneCount . '</a>',
+                '<a href="' . $listUrl . '">' . $reparationCount . '</a>',
+            ],
+            'widgetName' => 'warehouseStats',
+        ];
+    }
+
+    /**
+     * Count registration certificates per warehouse.
+     * GROUP BY aggregation has no ORM equivalent — raw SQL is intentional here.
+     *
+     * @param  int   $interneWarehouseID    ID of the internal warehouse
+     * @param  int   $reparationWarehouseID ID of the repair warehouse
+     * @return array                        Map of warehouse ID => count
+     */
+    private function getWarehouseCounts(int $interneWarehouseID, int $reparationWarehouseID): array
+    {
+        $warehouseIds = array_values(array_filter([$interneWarehouseID, $reparationWarehouseID]));
+        if (empty($warehouseIds)) {
+            return [];
+        }
+
+        $warehouseIdsStr = implode(',', array_map('intval', $warehouseIds));
+
+        $sql  = 'SELECT ps.fk_entrepot, COUNT(DISTINCT rcfr.rowid) as nb';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'dolicar_registrationcertificatefr rcfr';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.rowid = rcfr.fk_lot';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_batch pb ON pb.batch = pl.batch AND pb.qty > 0';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock AND ps.fk_product = pl.fk_product';
+        $sql .= ' WHERE rcfr.entity IN (' . getEntity('registrationcertificatefr') . ')';
+        $sql .= ' AND rcfr.status >= 0';
+        $sql .= ' AND rcfr.fk_lot IS NOT NULL AND rcfr.fk_lot > 0';
+        $sql .= ' AND ps.fk_entrepot IN (' . $warehouseIdsStr . ')';
+        $sql .= ' GROUP BY ps.fk_entrepot';
+
+        $counts = [];
+        $resql  = $this->db->query($sql);
+
+        if ($resql) {
+            while ($obj = $this->db->fetch_object($resql)) {
+                $counts[(int) $obj->fk_entrepot] = (int) $obj->nb;
+            }
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Build the dashboard list showing registration certificates sorted by warehouse.
+     * GROUP BY + JOIN aggregation has no ORM equivalent — raw SQL is intentional here.
+     *
+     * @param  int   $interneWarehouseID    ID of the internal warehouse
+     * @param  int   $reparationWarehouseID ID of the repair warehouse
+     * @return array                        List data array, empty if no data
+     */
+    private function loadWarehouseList(int $interneWarehouseID, int $reparationWarehouseID): array
+    {
+        global $langs;
+
+        $warehouseIds = array_values(array_filter([$interneWarehouseID, $reparationWarehouseID]));
+        if (empty($warehouseIds)) {
+            return [];
+        }
+
+        $warehouseIdsStr = implode(',', array_map('intval', $warehouseIds));
+
+        $sql  = 'SELECT rcfr.rowid, rcfr.a_registration_number, rcfr.d1_vehicle_brand, rcfr.d3_vehicle_model,';
+        $sql .= ' e.rowid as warehouse_id, e.ref as warehouse_ref';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'dolicar_registrationcertificatefr rcfr';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_lot pl ON pl.rowid = rcfr.fk_lot';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_batch pb ON pb.batch = pl.batch AND pb.qty > 0';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'product_stock ps ON ps.rowid = pb.fk_product_stock AND ps.fk_product = pl.fk_product';
+        $sql .= ' INNER JOIN ' . MAIN_DB_PREFIX . 'entrepot e ON e.rowid = ps.fk_entrepot';
+        $sql .= ' WHERE rcfr.entity IN (' . getEntity('registrationcertificatefr') . ')';
+        $sql .= ' AND rcfr.status >= 0';
+        $sql .= ' AND rcfr.fk_lot IS NOT NULL AND rcfr.fk_lot > 0';
+        $sql .= ' AND ps.fk_entrepot IN (' . $warehouseIdsStr . ')';
+        $sql .= ' ORDER BY e.rowid ASC, rcfr.a_registration_number ASC';
+
+        $listData = [];
+        $resql    = $this->db->query($sql);
+
+        if ($resql) {
+            while ($obj = $this->db->fetch_object($resql)) {
+                $cardUrl    = dol_buildpath('/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . ((int) $obj->rowid);
+                $refLink    = '<a href="' . $cardUrl . '">' . dol_escape_htmltag($obj->a_registration_number) . '</a>';
+                $brandModel = dol_escape_htmltag(trim($obj->d1_vehicle_brand . ' ' . $obj->d3_vehicle_model));
+
+                $listData[] = [
+                    'Ref'       => ['value' => $refLink],
+                    'Vehicle'   => ['value' => $brandModel, 'morecss' => 'center'],
+                    'Warehouse' => ['value' => dol_escape_htmltag($obj->warehouse_ref), 'morecss' => 'center'],
+                ];
+            }
+        }
+
+        if (empty($listData)) {
+            return [];
+        }
+
+        return [
+            'title'  => $langs->transnoentities('DashboardWarehouseList'),
+            'picto'  => 'fas fa-warehouse',
+            'name'   => 'warehouseList',
+            'labels' => [
+                'Ref'       => 'RegistrationNumber',
+                'Vehicle'   => 'Vehicle',
+                'Warehouse' => 'Warehouse',
+            ],
+            'data'   => $listData,
+        ];
+    }
+
+    /**
+     * Build the recent activities list.
+     * Uses RegistrationCertificateFr::fetchAll() and fetchObjectLinked() for ORM-based loading.
+     * ActionComm multi-element query still uses SQL (no ORM equivalent).
+     *
+     * @return array List data array
+     * @throws Exception
+     */
+    private function loadRecentActivitiesList(): array
+    {
+        global $langs;
+
+        require_once __DIR__ . '/registrationcertificatefr.class.php';
+
+        $cgObject = new RegistrationCertificateFr($this->db);
+        // fetchAll() handles entity filtering automatically via ismultientitymanaged
+        $cgList   = $cgObject->fetchAll('', '', 0, 0, ['customsql' => 't.status >= 0']);
+
+        if (!is_array($cgList) || empty($cgList)) {
+            return $this->buildActivitiesListResult([], $langs);
+        }
+
+        $cgIds         = [];
+        $lotIds        = [];
+        $cgPlaques     = [];
+        $linkedByType  = [];
+        $linkedPlaques = [];
+
+        foreach ($cgList as $cg) {
+            $cgIds[]            = $cg->id;
+            $cgPlaques[$cg->id] = $cg->a_registration_number;
+
+            if (!empty($cg->fk_lot) && $cg->fk_lot > 0) {
+                $lotIds[]                               = (int) $cg->fk_lot;
+                $cgPlaques['lot_' . (int) $cg->fk_lot] = $cg->a_registration_number;
+            }
+
+            // Use ORM to fetch linked objects (invoices, orders, proposals, controls, etc.)
+            $cg->fetchObjectLinked();
+            foreach ($cg->linkedObjects as $type => $linkedObjArray) {
+                foreach ($linkedObjArray as $linkedObjId => $linkedObj) {
+                    $linkedByType[$type][]                          = (int) $linkedObjId;
+                    $linkedPlaques[$type . '_' . (int) $linkedObjId] = $cg->a_registration_number;
+                }
+            }
+        }
+
+        $cgIdsStr  = implode(',', $cgIds);
+        $orClauses = [];
+
+        $orClauses[] = "(ac.elementtype LIKE '%registrationcertificatefr%' AND ac.fk_element IN ($cgIdsStr))";
+
+        if (!empty($lotIds)) {
+            $lotIdsStr   = implode(',', array_unique($lotIds));
+            $orClauses[] = "(ac.elementtype = 'productlot' AND ac.fk_element IN ($lotIdsStr))";
+        }
+
+        foreach ($linkedByType as $type => $ids) {
+            $idsStr      = implode(',', array_unique($ids));
+            $escaped     = $this->db->escape($type);
+            $orClauses[] = "(ac.fk_element IN ($idsStr) AND (ac.elementtype = '$escaped' OR ac.elementtype LIKE '$escaped@%'))";
+        }
+
+        // ActionComm multi-element query — no ORM equivalent for this pattern
+        $sql  = 'SELECT ac.id, ac.label, ac.datep, ac.fk_element, ac.elementtype,';
+        $sql .= ' u.login, u.lastname, u.firstname';
+        $sql .= ' FROM ' . MAIN_DB_PREFIX . 'actioncomm ac';
+        $sql .= ' LEFT JOIN ' . MAIN_DB_PREFIX . 'user u ON u.rowid = ac.fk_user_action';
+        $sql .= ' WHERE ac.entity IN (' . getEntity('agenda') . ')';
+        $sql .= ' AND (' . implode(' OR ', $orClauses) . ')';
+        $sql .= ' ORDER BY ac.datep DESC LIMIT 15';
+
+        $listData = [];
+        $resql    = $this->db->query($sql);
+
+        if ($resql) {
+            while ($obj = $this->db->fetch_object($resql)) {
+                $dateStr    = dol_print_date($this->db->jdate($obj->datep), 'dayhour');
+                $userStr    = trim($obj->firstname . ' ' . $obj->lastname) ?: $obj->login;
+                $label      = dol_escape_htmltag($obj->label);
+                $isCgDirect = strpos((string) $obj->elementtype, 'registrationcertificatefr') !== false;
+
+                if ($isCgDirect && isset($cgPlaques[(int) $obj->fk_element])) {
+                    $cardUrl = dol_buildpath('/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . ((int) $obj->fk_element);
+                    $label   = '<a href="' . $cardUrl . '">' . $label . '</a>';
+                }
+
+                if (!$isCgDirect) {
+                    $plaque = $cgPlaques['lot_' . (int) $obj->fk_element]
+                        ?? $linkedPlaques[$obj->elementtype . '_' . (int) $obj->fk_element]
+                        ?? $linkedPlaques[explode('@', $obj->elementtype)[0] . '_' . (int) $obj->fk_element]
+                        ?? null;
+
+                    if ($plaque !== null) {
+                        $label .= ' <span style="border:1px solid #d35968;padding:1px 5px;border-radius:3px;font-size:0.85em;color:#d35968;">'
+                               . dol_escape_htmltag($plaque) . '</span>';
+                    }
+                }
+
+                $listData[] = [
+                    'Ref'  => ['value' => $label],
+                    'Date' => ['value' => $dateStr, 'morecss' => 'center nowraponall'],
+                    'User' => ['value' => dol_escape_htmltag($userStr), 'morecss' => 'center'],
+                ];
+            }
+        }
+
+        return $this->buildActivitiesListResult($listData, $langs);
+    }
+
+    /**
+     * Wrap activity rows in the list structure expected by SaturneDashboard
+     *
+     * @param  array     $listData Rows (may be empty)
+     * @param  Translate $langs    Translation object
+     * @return array               Complete list array
+     */
+    private function buildActivitiesListResult(array $listData, $langs): array
+    {
+        if (empty($listData)) {
+            $listData[] = [
+                'Ref'  => ['value' => '<em>' . $langs->transnoentities('NoRecentActivityDolicar') . '</em>'],
+                'Date' => ['value' => '', 'morecss' => 'center'],
+                'User' => ['value' => '', 'morecss' => 'center'],
+            ];
+        }
+
+        return [
+            'title'  => $langs->transnoentities('DashboardRecentActivities'),
+            'picto'  => 'fontawesome_fa-history_fas_#d35968',
+            'name'   => 'recentActivities',
+            'labels' => [
+                'Ref'  => 'DashboardActivity',
+                'Date' => 'Date',
+                'User' => 'UserAuthor',
+            ],
+            'data'   => $listData,
+        ];
+    }
+
+    /**
+     * Build the overdue technical inspection list.
+     * Uses RegistrationCertificateFr::fetchAll() and Productlot::fetch() via ORM.
+     * Expiry check and day calculation are done in PHP after ORM loading.
+     *
+     * @return array List data array
+     * @throws Exception
+     */
+    private function loadOverdueCTList(): array
+    {
+        global $langs;
+
+        require_once __DIR__ . '/registrationcertificatefr.class.php';
+        require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+
+        $cgObject  = new RegistrationCertificateFr($this->db);
+        $lotObject = new Productlot($this->db);
+        $now       = dol_now();
+
+        // fetchAll() handles entity filtering automatically
+        $cgList = $cgObject->fetchAll('', '', 0, 0, ['customsql' => 't.status >= 0 AND t.fk_lot > 0']);
+
+        $overdueItems = [];
+
+        if (is_array($cgList)) {
+            foreach ($cgList as $cg) {
+                $lotObject->fetch((int) $cg->fk_lot);
+
+                if (empty($lotObject->eatby) || $lotObject->eatby <= 0 || $lotObject->eatby >= $now) {
+                    continue;
+                }
+
+                $overdueItems[] = [
+                    'cg'   => $cg,
+                    'lot'  => clone $lotObject,
+                    'days' => (int) floor(($now - $lotObject->eatby) / 86400),
+                ];
+            }
+        }
+
+        // Sort by eatby ASC — most overdue (oldest expiry) first
+        usort($overdueItems, static fn($a, $b) => $a['lot']->eatby <=> $b['lot']->eatby);
+
+        $listData = [];
+
+        foreach ($overdueItems as $item) {
+            $cg   = $item['cg'];
+            $lot  = $item['lot'];
+            $days = $item['days'];
+
+            if ($days >= 90) {
+                $color = '#8B0000';
+            } elseif ($days >= 60) {
+                $color = '#C0392B';
+            } elseif ($days >= 30) {
+                $color = '#E06C00';
+            } else {
+                $color = '#E8A317';
+            }
+
+            $cardUrl    = dol_buildpath('/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 1) . '?id=' . $cg->id;
+            $refLink    = '<a href="' . $cardUrl . '">' . dol_escape_htmltag($cg->a_registration_number) . '</a>';
+            $brandModel = dol_escape_htmltag(trim($cg->d1_vehicle_brand . ' ' . $cg->d3_vehicle_model));
+            $eatbyDate  = dol_print_date($lot->eatby, 'day');
+            $daysHtml   = '<span style="background:' . $color . ';color:#fff;padding:2px 8px;border-radius:12px;font-weight:bold;font-size:0.85em;">'
+                        . $days . ' j</span>';
+
+            $listData[] = [
+                'Ref'        => ['value' => $refLink],
+                'Vehicle'    => ['value' => $brandModel, 'morecss' => 'center'],
+                'ExpiryDate' => ['value' => '<span style="color:#E05353;">' . $eatbyDate . '</span>', 'morecss' => 'center nowraponall'],
+                'DaysOver'   => ['value' => $daysHtml, 'morecss' => 'center nowraponall'],
+            ];
+        }
+
+        if (empty($listData)) {
+            $listData[] = [
+                'Ref'        => ['value' => '<em>' . $langs->transnoentities('NoCTOverdueDolicar') . '</em>'],
+                'Vehicle'    => ['value' => '', 'morecss' => 'center'],
+                'ExpiryDate' => ['value' => '', 'morecss' => 'center'],
+                'DaysOver'   => ['value' => '', 'morecss' => 'center'],
+            ];
+        }
+
+        return [
+            'title'  => $langs->transnoentities('DashboardOverdueCT'),
+            'picto'  => 'fontawesome_fa-exclamation-triangle_fas_#E05353',
+            'name'   => 'overdueCtList',
+            'labels' => [
+                'Ref'        => 'RegistrationNumber',
+                'Vehicle'    => 'Vehicle',
+                'ExpiryDate' => 'ExpiryDate',
+                'DaysOver'   => 'DaysOverdue',
+            ],
+            'data'   => $listData,
+        ];
     }
 }

--- a/core/triggers/interface_99_modDoliCar_DoliCarTriggers.class.php
+++ b/core/triggers/interface_99_modDoliCar_DoliCarTriggers.class.php
@@ -105,6 +105,20 @@ class InterfaceDoliCarTriggers extends DolibarrTriggers
         }
 
         switch ($action) {
+            case 'REGISTRATIONCERTIFICATEFR_CREATE':
+                if (!empty($object->fk_lot) && $object->fk_lot > 0) {
+                    $lotActionComm              = new ActionComm($this->db);
+                    $lotActionComm->code        = 'AC_PRODUCTBATCH_CREATE';
+                    $lotActionComm->type_code   = 'AC_OTH_AUTO';
+                    $lotActionComm->fk_element  = $object->fk_lot;
+                    $lotActionComm->elementtype = 'productlot';
+                    $lotActionComm->label       = $langs->transnoentities('LotCreatedForRegistrationCertificate', $object->a_registration_number);
+                    $lotActionComm->datep       = dol_now();
+                    $lotActionComm->userownerid = $user->id;
+                    $lotActionComm->percentage  = -1;
+                    $lotActionComm->create($user);
+                }
+                break;
             case 'PROPAL_CREATE' :
             case 'ORDER_CREATE' :
             case 'BILL_CREATE' :

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -44,6 +44,17 @@ Bicycle           = Vélo
 DashboardRemainingRequestsRequest         = Jetons de recherche de plaque d'immatriculation
 DashboardNumberOfRegestrationCertifatesFr = Nombre de carte grises
 DashboardCarState                         = Statut des véhicules
+DashboardWarehouseStats                   = Cartes grises par entrepôt
+DashboardWarehouseList                    = Liste des cartes grises par entrepôt
+DashboardRecentActivities                 = Activité récente
+DashboardOverdueCT                        = Contrôles techniques dépassés
+DashboardActivity                         = Activité
+Warehouse                                 = Entrepôt
+ExpiryDate                                = Date de péremption
+NoRecentActivityDolicar                   = Aucune activité récente
+NoCTOverdueDolicar                        = Aucun contrôle technique dépassé
+LotCreatedForRegistrationCertificate      = Numéro de série créé pour la carte grise %s
+DaysOverdue                               = Dépassement
 
 
 #


### PR DESCRIPTION
#389

## Summary

- Widget cartes grises par entrepot (Interne / Reparation), cliquable vers la liste filtree
- Liste des cartes grises par entrepot sur le tableau de bord
- Liste activite recente : evenements CG, lots, factures/commandes/propales, controles DigiQuali
- Liste CT depasses avec badge colore par seuil (30/60/90 jours), tries du plus depasse au moins
- ActionComm cree sur le lot lors de la creation d une carte grise (trigger)
- Suppression widget Informations et graphique Statut des vehicules

## Test plan

- [ ] Verifier le widget entrepot avec les compteurs Interne / Reparation
- [ ] Creer une carte grise et verifier qu elle apparait dans l activite recente
- [ ] Verifier les badges de depassement CT avec les bonnes couleurs
- [ ] Verifier que la liste CT depasses apparait en premier

Generated with Claude Code