### PR TITLE
#404 [RegistrationCertificateFr] feat: add vehicle history tab with ActionComm events

### DIFF
--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -1,0 +1,145 @@
+<?php
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+ * \ingroup dolicar
+ * \brief   Template for vehicle history events (CT, Révision, Accident, Autre)
+ */
+
+/**
+ * The following vars must be defined:
+ * Global   : $db, $langs, $form, $user
+ * Variable : $object (RegistrationCertificateFr), $permissiontoadd
+ */
+
+require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
+
+$vehicleEventTypes = [
+    'AC_DOLICAR_CT'       => $langs->transnoentities('VehicleEventTypeCT'),
+    'AC_DOLICAR_REVISION' => $langs->transnoentities('VehicleEventTypeRevision'),
+    'AC_DOLICAR_ACCIDENT' => $langs->transnoentities('VehicleEventTypeAccident'),
+    'AC_DOLICAR_AUTRE'    => $langs->transnoentities('VehicleEventTypeAutre'),
+];
+
+$vehicleEventIcons = [
+    'AC_DOLICAR_CT'       => 'fa-check-circle',
+    'AC_DOLICAR_REVISION' => 'fa-wrench',
+    'AC_DOLICAR_ACCIDENT' => 'fa-exclamation-triangle',
+    'AC_DOLICAR_AUTRE'    => 'fa-circle',
+];
+
+$vehicleEventColors = [
+    'AC_DOLICAR_CT'       => '#5BA86E',
+    'AC_DOLICAR_REVISION' => '#E8A317',
+    'AC_DOLICAR_ACCIDENT' => '#E05353',
+    'AC_DOLICAR_AUTRE'    => '#888888',
+];
+
+$out = '';
+
+if (empty($object->fk_lot) || $object->fk_lot <= 0) {
+    return;
+}
+
+// === Add event form ===
+if (!empty($permissiontoadd)) {
+    $out .= load_fiche_titre($langs->transnoentities('AddVehicleEvent'), '', 'dolicar_color@dolicar');
+
+    $out .= '<form method="POST" action="' . dol_escape_htmltag($_SERVER['PHP_SELF']) . '?id=' . $object->id . '">';
+    $out .= '<input type="hidden" name="token" value="' . newToken() . '">';
+    $out .= '<input type="hidden" name="action" value="add_vehicle_event">';
+
+    $out .= '<table class="border centpercent tableforfield">';
+
+    $out .= '<tr>';
+    $out .= '<td class="titlefield fieldrequired">' . $langs->transnoentities('VehicleEventType') . '</td>';
+    $out .= '<td>' . Form::selectarray('event_type', $vehicleEventTypes, GETPOST('event_type', 'aZ09'), 0, 0, 0, '', 0, 0, 0, '', 'minwidth200') . '</td>';
+    $out .= '</tr>';
+
+    $out .= '<tr>';
+    $out .= '<td class="fieldrequired">' . $langs->transnoentities('Date') . '</td>';
+    $out .= '<td>' . $form->selectDate(dol_now(), 'event_date', 0, 0, 0, '', 1, 1) . '</td>';
+    $out .= '</tr>';
+
+    $out .= '<tr>';
+    $out .= '<td>' . $langs->transnoentities('Mileage') . '</td>';
+    $out .= '<td><input type="number" name="event_mileage" class="flat minwidth100" value="' . (GETPOSTINT('event_mileage') ?: '') . '" min="0"> km</td>';
+    $out .= '</tr>';
+
+    $out .= '<tr>';
+    $out .= '<td>' . $langs->transnoentities('Note') . '</td>';
+    $out .= '<td><textarea name="event_note" class="flat minwidth400" rows="2">' . dol_escape_htmltag(GETPOST('event_note', 'restricthtml')) . '</textarea></td>';
+    $out .= '</tr>';
+
+    $out .= '</table>';
+
+    $out .= '<div class="tabsAction">';
+    $out .= '<input type="submit" class="butAction" value="' . $langs->transnoentities('Save') . '">';
+    $out .= '</div>';
+
+    $out .= '</form>';
+}
+
+// === Event history list ===
+$allowedCodes = array_keys($vehicleEventTypes);
+$codeFilter   = " AND a.code IN ('" . implode("','", $allowedCodes) . "')";
+
+$actionComm = new ActionComm($db);
+$eventsList = $actionComm->getActions(0, (int) $object->fk_lot, 'productlot', $codeFilter, 'a.datep', 'DESC');
+
+$out .= load_fiche_titre($langs->transnoentities('VehicleHistory'), '', 'dolicar_color@dolicar');
+$out .= '<table class="noborder centpercent">';
+$out .= '<tr class="liste_titre">';
+$out .= '<td>' . $langs->transnoentities('VehicleEventType') . '</td>';
+$out .= '<td class="center">' . $langs->transnoentities('Date') . '</td>';
+$out .= '<td class="center">' . $langs->transnoentities('Mileage') . '</td>';
+$out .= '<td>' . $langs->transnoentities('Note') . '</td>';
+$out .= '<td class="center">' . $langs->transnoentities('UserAuthor') . '</td>';
+$out .= '</tr>';
+
+if (is_array($eventsList) && !empty($eventsList)) {
+    foreach ($eventsList as $evt) {
+        $evt->fetch_optionals();
+
+        $ownerUser = new User($db);
+        $ownerUser->fetch($evt->userownerid);
+
+        $code    = $evt->code;
+        $icon    = $vehicleEventIcons[$code] ?? 'fa-circle';
+        $color   = $vehicleEventColors[$code] ?? '#888888';
+        $label   = $vehicleEventTypes[$code] ?? dol_escape_htmltag($evt->label);
+        $km      = (int) ($evt->array_options['options_starting_mileage'] ?? 0);
+        $userStr = $ownerUser->getNomUrl(1);
+        $badge   = '<span style="color:' . $color . ';font-weight:bold;"><i class="fas ' . $icon . '"></i> ' . $label . '</span>';
+
+        $out .= '<tr class="oddeven">';
+        $out .= '<td class="nowrap">' . $badge . '</td>';
+        $out .= '<td class="center nowraponall">' . dol_print_date($evt->datep, 'day') . '</td>';
+        $out .= '<td class="center">' . ($km > 0 ? price($km, 0, '', 1, 0) . ' km' : '') . '</td>';
+        $out .= '<td>' . dol_escape_htmltag((string) $evt->note_private) . '</td>';
+        $out .= '<td class="center nowraponall">' . $userStr . '</td>';
+        $out .= '</tr>';
+    }
+} else {
+    $out .= '<tr><td colspan="5"><em>' . $langs->transnoentities('NoVehicleHistory') . '</em></td></tr>';
+}
+
+$out .= '</table>';
+
+print $out;

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -236,6 +236,17 @@ FindVINInRepertory = Rechercher un VIN
 VINWasAlreadyExisting = Ce VIN existe déjà
 UpdateCarBrandsList    = Mettre à jour la liste
 CarBrandsUpdated       = La liste des marques a été mise à jour
+
+# Vehicle history - Historique véhicule
+AddVehicleEvent            = Ajouter un événement véhicule
+VehicleEventType           = Type d'événement
+VehicleEventTypeCT         = Contrôle technique
+VehicleEventTypeRevision   = Révision
+VehicleEventTypeAccident   = Accident
+VehicleEventTypeAutre      = Autre
+VehicleHistory             = Historique du véhicule
+NoVehicleHistory           = Aucun événement enregistré
+VehicleEventAdded          = Événement véhicule ajouté avec succès
 ErrorUpdateCarBrandsFromApi = Erreur lors de la mise à jour des marques depuis l''API : %s
 ErrorUpdateCarBrandsFromApiBadResponse = Réponse invalide de l''API lors de la mise à jour des marques
 ErrorUpdateCarBrandsFromApiNoData = Aucune donnée de marque trouvée dans la réponse de l''API

--- a/lib/dolicar_registrationcertificatefr.lib.php
+++ b/lib/dolicar_registrationcertificatefr.lib.php
@@ -43,6 +43,11 @@ function registrationcertificatefr_prepare_head(RegistrationCertificateFr $objec
     $head[$h][0] = dol_buildpath('dolicar/view/registrationcertificatefr/registrationcertificatefr_linkedobjects.php', 1) . '?id=' . $object->id;
     $head[$h][1] = $conf->browser->layout == 'classic' ? '<i class="fas fa-link pictofixedwidth"></i>' . $langs->trans('LinkedObjects') : '<i class="fas fa-link"></i>';
     $head[$h][2] = 'linkedobjects';
+    $h++;
+
+    $head[$h][0] = dol_buildpath('dolicar/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php', 1) . '?id=' . $object->id;
+    $head[$h][1] = $conf->browser->layout == 'classic' ? '<i class="fas fa-history pictofixedwidth"></i>' . $langs->trans('VehicleHistory') : '<i class="fas fa-history"></i>';
+    $head[$h][2] = 'vehiclehistory';
 
     return saturne_object_prepare_head($object, $head);
 }

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -1,0 +1,139 @@
+<?php
+/* Copyright (C) 2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    registrationcertificatefr_vehiclehistory.php
+ * \ingroup dolicar
+ * \brief   Page to view and add vehicle history events for a carte grise
+ */
+
+// Load DoliCar environment
+if (file_exists('../dolicar.main.inc.php')) {
+    require_once __DIR__ . '/../dolicar.main.inc.php';
+} elseif (file_exists('../../dolicar.main.inc.php')) {
+    require_once __DIR__ . '/../../dolicar.main.inc.php';
+} else {
+    die('Include of dolicar main fails');
+}
+
+// Load Dolibarr libraries
+require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+
+// Load DoliCar libraries
+require_once __DIR__ . '/../../lib/dolicar_registrationcertificatefr.lib.php';
+require_once __DIR__ . '/../../class/registrationcertificatefr.class.php';
+
+// Global variables definitions
+global $db, $form, $langs, $user;
+
+// Load translation files required by the page
+saturne_load_langs();
+
+// Get parameters
+$id     = GETPOST('id', 'int');
+$ref    = GETPOST('ref', 'alpha');
+$action = GETPOST('action', 'aZ09');
+$cancel = GETPOST('cancel', 'aZ09');
+
+// Initialize technical objects
+$object      = new RegistrationCertificateFr($db);
+$extrafields = new ExtraFields($db);
+$form        = new Form($db);
+
+// Load object
+require_once DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php'; // Must be included, not include_once
+
+// Security check - Protection if external user
+$permissionToRead = $user->rights->dolicar->registrationcertificatefr->read;
+$permissiontoadd  = $user->rights->dolicar->registrationcertificatefr->write;
+saturne_check_access($permissionToRead);
+
+/*
+ * Actions
+ */
+
+if ($action == 'add_vehicle_event' && !empty($permissiontoadd) && !empty($object->fk_lot) && $object->fk_lot > 0) {
+    $error        = 0;
+    $allowedCodes = ['AC_DOLICAR_CT', 'AC_DOLICAR_REVISION', 'AC_DOLICAR_ACCIDENT', 'AC_DOLICAR_AUTRE'];
+    $eventType    = GETPOST('event_type', 'aZ09');
+    $eventDate    = dol_mktime(12, 0, 0, GETPOSTINT('event_datemonth'), GETPOSTINT('event_dateday'), GETPOSTINT('event_dateyear'));
+    $eventMileage = GETPOSTINT('event_mileage');
+    $eventNote    = GETPOST('event_note', 'restricthtml');
+
+    if (!in_array($eventType, $allowedCodes, true)) {
+        setEventMessages($langs->transnoentities('VehicleEventType') . ' ' . $langs->transnoentities('NotValid'), null, 'errors');
+        $error++;
+    }
+
+    if (!$error) {
+        $eventLabelKeys = [
+            'AC_DOLICAR_CT'       => 'VehicleEventTypeCT',
+            'AC_DOLICAR_REVISION' => 'VehicleEventTypeRevision',
+            'AC_DOLICAR_ACCIDENT' => 'VehicleEventTypeAccident',
+            'AC_DOLICAR_AUTRE'    => 'VehicleEventTypeAutre',
+        ];
+
+        $actionComm               = new ActionComm($db);
+        $actionComm->code         = $eventType;
+        $actionComm->type_code    = 'AC_OTH';
+        $actionComm->fk_element   = (int) $object->fk_lot;
+        $actionComm->elementtype  = 'productlot';
+        $actionComm->label        = $langs->transnoentities($eventLabelKeys[$eventType]);
+        $actionComm->datep        = $eventDate ?: dol_now();
+        $actionComm->userownerid  = $user->id;
+        $actionComm->percentage   = -1;
+        $actionComm->note_private = $eventNote;
+
+        $result = $actionComm->create($user);
+        if ($result > 0 && $eventMileage > 0) {
+            $actionComm->array_options['options_starting_mileage'] = $eventMileage;
+            $actionComm->insertExtraFields();
+        }
+
+        if ($result > 0) {
+            setEventMessages($langs->transnoentities('VehicleEventAdded'), null, 'mesgs');
+            header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $object->id);
+            exit;
+        } else {
+            setEventMessages($actionComm->error, $actionComm->errors, 'errors');
+        }
+    }
+}
+
+/*
+ * View
+ */
+
+$title   = $langs->trans('VehicleHistory') . ' - ' . $langs->trans(ucfirst($object->element));
+$helpUrl = 'FR:Module_DoliCar';
+
+saturne_header(0, '', $title, $helpUrl);
+
+if ($id > 0 || !empty($ref)) {
+    saturne_get_fiche_head($object, 'vehiclehistory', $title);
+    saturne_banner_tab($object);
+
+    print '<div class="fichecenter">';
+    require_once __DIR__ . '/../../core/tpl/registrationcertificatefr_vehicle_history.tpl.php';
+    print '</div>';
+
+    print dol_get_fiche_end();
+}
+
+// End of page
+llxFooter();
+$db->close();


### PR DESCRIPTION
#404

## Summary
- Nouvel onglet Historique du vehicule sur la fiche carte grise
- 4 types d'evenements : Controle technique, Revision, Accident, Autre stockes comme ActionComm lies au VIN (productlot)
- Formulaire d'ajout (type, date, kilometrage, note) avec redirection apres enregistrement
- Liste de l'historique avec badge colore par type, kilometrage, note et lien cliquable vers l'auteur (getNomUrl)
- Utilise ActionComm::getActions() et fetch_optionals() (ORM natif Dolibarr, pas de SQL brut)

## Test plan
- Ouvrir une carte grise ayant un numero de serie (VIN) lie
- Verifier la presence de l'onglet Historique du vehicule
- Creer un evenement de chaque type (CT, Revision, Accident, Autre) avec kilometrage et note
- Verifier que chaque evenement apparait dans la liste avec la bonne couleur et icone
- Verifier que le lien sur l'auteur est cliquable
- Verifier que la page affiche le message vide si aucun evenement

Generated with Claude Code