### PR TITLE
#411 [ExtraField] fix: hide registration_number on propal and invoice card

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -210,6 +210,10 @@ class ActionsDoliCar
             }
         }
 
+        if (preg_match('/propalcard|invoicecard/', $parameters['context'])) {
+            $extrafields->attributes[$object->element]['list']['registration_number'] = 0;
+        }
+
         return 0; // or return 1 to replace standard code
     }
 


### PR DESCRIPTION
## Changements
- Masquage du champ extrafield `registration_number` sur les cards de proposition commerciale et de facture
- Le champ reste sauvegarde automatiquement via le hook `doActions` lors de la selection d'un certificat immatriculation

## Fichiers modifies
- `class/actions_dolicar.class.php`

## Issue
#411