### PR TITLE
#426 [VehicleHistory] fix: prevent assigning the same element to multiple vehicle events

### DIFF
--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -30,6 +30,9 @@
  *            $catLabels (array id => ['label' => string, 'data-html' => string])
  *            $eventsList (array of ActionComm)
  *            $evtCatById (array evtId => Categorie)
+ *            $alreadyLinkedFactureIds (array of facture ids already linked to an event)
+ *            $alreadyLinkedPropalIds  (array of propal ids already linked to an event)
+ *            $alreadyLinkedControlIds (array of control ids already linked to an event)
  */
 
 require_once DOL_DOCUMENT_ROOT . '/user/class/user.class.php';
@@ -45,6 +48,11 @@ $out = '';
 
 // === Add event form ===
 if (!empty($permissiontoadd)) {
+    // Exclude elements already linked to an existing event so the same one cannot be assigned twice
+    $factureFilter = !empty($alreadyLinkedFactureIds) ? ':0:(t.rowid:notin:' . implode(',', $alreadyLinkedFactureIds) . ')' : '';
+    $propalFilter  = !empty($alreadyLinkedPropalIds) ? ':0:(t.rowid:notin:' . implode(',', $alreadyLinkedPropalIds) . ')' : '';
+    $controlFilter = !empty($alreadyLinkedControlIds) ? ':0:(t.rowid:notin:' . implode(',', $alreadyLinkedControlIds) . ')' : '';
+
     $out .= load_fiche_titre($langs->transnoentities('AddVehicleEvent'), '', 'dolicar_color@dolicar');
 
     $out .= '<form method="POST" action="' . dol_escape_htmltag($_SERVER['PHP_SELF']) . '?id=' . $object->id . '">';
@@ -75,17 +83,17 @@ if (!empty($permissiontoadd)) {
 
     $out .= '<tr>';
     $out .= '<td>' . img_picto('', 'bill', 'class="pictofixedwidth"') . $langs->transnoentities('Invoices') . '</td>';
-    $out .= '<td>' . $form->selectForForms('Facture:compta/facture/class/facture.class.php', 'event_fk_facture', GETPOSTINT('event_fk_facture'), 1, '', '', 'minwidth300') . '</td>';
+    $out .= '<td>' . $form->selectForForms('Facture:compta/facture/class/facture.class.php' . $factureFilter, 'event_fk_facture', GETPOSTINT('event_fk_facture'), 1, '', '', 'minwidth300') . '</td>';
     $out .= '</tr>';
 
     $out .= '<tr>';
     $out .= '<td>' . img_picto('', 'propal', 'class="pictofixedwidth"') . $langs->transnoentities('Proposals') . '</td>';
-    $out .= '<td>' . $form->selectForForms('Propal:comm/propal/class/propal.class.php', 'event_fk_propal', GETPOSTINT('event_fk_propal'), 1, '', '', 'minwidth300') . '</td>';
+    $out .= '<td>' . $form->selectForForms('Propal:comm/propal/class/propal.class.php' . $propalFilter, 'event_fk_propal', GETPOSTINT('event_fk_propal'), 1, '', '', 'minwidth300') . '</td>';
     $out .= '</tr>';
 
     $out .= '<tr>';
     $out .= '<td><i class="fas fa-tasks pictofixedwidth"></i>' . $langs->transnoentities('Controls') . '</td>';
-    $out .= '<td>' . $form->selectForForms('Control:custom/digiquali/class/control.class.php', 'event_fk_control', GETPOSTINT('event_fk_control'), 1, '', '', 'minwidth300') . '</td>';
+    $out .= '<td>' . $form->selectForForms('Control:custom/digiquali/class/control.class.php' . $controlFilter, 'event_fk_control', GETPOSTINT('event_fk_control'), 1, '', '', 'minwidth300') . '</td>';
     $out .= '</tr>';
 
     $out .= '</table>';

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -304,6 +304,7 @@ VehicleEventType               = Type d'événement
 VehicleHistory                 = Historique du véhicule
 NoVehicleHistory               = Aucun événement enregistré
 VehicleEventAdded              = Événement véhicule ajouté avec succès
+VehicleEventElementAlreadyLinked = Cet élément (%s) est déjà associé à un autre événement de ce véhicule
 LinkedDocuments                = Documents liés
 Invoices                       = Factures
 Proposals                      = Devis

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -165,6 +165,23 @@ if (!empty($object->fk_lot) && $object->fk_lot > 0 && !empty($catById)) {
     }
 }
 
+// Collect elements already linked to an existing event to prevent assigning the same one twice
+$alreadyLinkedFactureIds = [];
+$alreadyLinkedPropalIds  = [];
+$alreadyLinkedControlIds = [];
+foreach ($eventsList as $linkedEvt) {
+    $linkedEvt->fetchObjectLinked(null, null, null, null, 'OR', 1, 'sourcetype', 0);
+    foreach (($linkedEvt->linkedObjectsIds['facture'] ?? []) as $facId) {
+        $alreadyLinkedFactureIds[(int) $facId] = (int) $facId;
+    }
+    foreach (($linkedEvt->linkedObjectsIds['propal'] ?? []) as $propalId) {
+        $alreadyLinkedPropalIds[(int) $propalId] = (int) $propalId;
+    }
+    foreach (($linkedEvt->linkedObjectsIds['control'] ?? []) as $controlId) {
+        $alreadyLinkedControlIds[(int) $controlId] = (int) $controlId;
+    }
+}
+
 /*
  * Actions
  */
@@ -182,6 +199,20 @@ if ($action == 'add_vehicle_event' && !empty($permissiontoadd) && !empty($object
     $selectedCat = new Categorie($db);
     if ($eventCategoryId <= 0 || $selectedCat->fetch($eventCategoryId) <= 0 || (int) $selectedCat->fk_parent !== $parentCategoryId) {
         setEventMessages($langs->transnoentities('VehicleEventType') . ' ' . $langs->transnoentities('NotValid'), null, 'errors');
+        $error++;
+    }
+
+    // Prevent assigning an element already linked to another event of this vehicle
+    if (!$error && $fkFacture > 0 && isset($alreadyLinkedFactureIds[$fkFacture])) {
+        setEventMessages($langs->transnoentities('VehicleEventElementAlreadyLinked', $langs->transnoentities('Invoices')), null, 'errors');
+        $error++;
+    }
+    if (!$error && $fkPropal > 0 && isset($alreadyLinkedPropalIds[$fkPropal])) {
+        setEventMessages($langs->transnoentities('VehicleEventElementAlreadyLinked', $langs->transnoentities('Proposals')), null, 'errors');
+        $error++;
+    }
+    if (!$error && $fkControl > 0 && isset($alreadyLinkedControlIds[$fkControl])) {
+        setEventMessages($langs->transnoentities('VehicleEventElementAlreadyLinked', $langs->transnoentities('Controls')), null, 'errors');
         $error++;
     }
 


### PR DESCRIPTION
Already-linked invoices, proposals and controls are now excluded from the
selection dropdowns (universal filter t.rowid:notin) so they cannot be picked
again, and a server-side guard rejects an element already linked to another
event of the same vehicle.
