### PR TITLE
#430 [ExtraField] fix: anchor printFieldListOption context regex to avoid null object

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -228,7 +228,7 @@ class ActionsDoliCar
     {
         global $extrafields, $langs;
 
-        if (preg_match('/propallist|orderlist|invoicelist/', $parameters['context'])) {
+        if (preg_match('/(^|:)(propallist|orderlist|invoicelist)(:|$)/', $parameters['context']) && is_object($object)) {
             $picto            = img_picto('', 'dolicar_color@dolicar', 'class="pictofixedwidth"');
             $extraFieldsNames = ['registration_number', 'vehicle_model', 'VIN_number', 'first_registration_date', 'mileage', 'registrationcertificatefr', 'linked_product', 'linked_lot'];
             foreach ($extraFieldsNames as $extraFieldsName) {


### PR DESCRIPTION
Closes #430

## Problem

`printFieldListOption()` guarded its logic with a **substring** regex:

```php
if (preg_match('/propallist|orderlist|invoicelist/', $parameters['context'])) {
```

`orderlist`/`invoicelist` are substrings of other page contexts, so the block also ran on:

| Page | Context | Effect |
|------|---------|--------|
| `fourn/commande/list.php` | `supplierorderlist` | hook called **without $object** → `Attempt to read property "element" on null` (line 223) |
| `commande/list_det.php` | `orderlistdetail` | hook called **without $object** → same warning |
| `fourn/facture/list.php` | `supplierinvoicelist` | $object present, but picto wrongly applied to supplier-invoice extrafields |

## Fix

Anchor the regex to full context tokens (start / `:` / end) so only the intended customer lists `propallist`, `orderlist`, `invoicelist` match, plus an `is_object($object)` safety guard:

```php
if (preg_match('/(^|:)(propallist|orderlist|invoicelist)(:|$)/', $parameters['context']) && is_object($object)) {
```

`formObjectOptions()` was checked and left unchanged: its supplier-card contexts (`ordersuppliercard`, `invoicesuppliercard`) do not match its regex (the word "supplier" is interleaved).