### PR TITLE
#337 [RegistrationCertificateFr] fix: delete carte grise definitively (hard delete)

### DIFF
--- a/class/registrationcertificatefr.class.php
+++ b/class/registrationcertificatefr.class.php
@@ -356,6 +356,21 @@ class RegistrationCertificateFr extends SaturneObject
     }
 
     /**
+     * Delete object in database
+     *
+     * Registration certificate deletion must be definitive (hard delete) so no soft-deleted row is kept in database.
+     *
+     * @param  User      $user       User that deletes
+     * @param  int<0,1>  $noTrigger  0 = launch triggers after, 1 = disable triggers
+     * @param  bool      $softDelete Keep object in database with a deleted status instead of removing it
+     * @return int<-1,1>             Return integer 0 < if KO, > 0 if OK
+     */
+    public function delete(User $user, int $noTrigger = 0, bool $softDelete = false): int
+    {
+        return parent::delete($user, $noTrigger, $softDelete);
+    }
+
+    /**
      * Return tooltip content array
      *
      * @param  array $params Tooltip params


### PR DESCRIPTION
## Contexte

Closes #337

La suppression d'une carte grise (`RegistrationCertificateFr`) passait par le comportement par défaut de `SaturneObject::delete()`, dont le 3ᵉ paramètre `$softDelete` vaut `true`. La ligne n'était donc pas réellement supprimée : elle restait en base avec le statut `-1` (Deleted). C'est le cas notamment de la mass-action « Supprimer » de la liste, qui appelle `$object->delete($user)`.

## Correctif

Override de `delete()` dans `class/registrationcertificatefr.class.php` pour basculer la valeur par défaut de `$softDelete` à `false` et déléguer à `parent::delete()` → suppression définitive (hard delete) via `deleteCommon()`.

- Couvre tous les points d'entrée existants (mass-action de la liste) et tout futur bouton « Supprimer » sur la fiche.
- Le paramètre `$softDelete` reste disponible pour les appelants qui souhaiteraient explicitement un soft delete.
- Diff minimal, aucun changement de schéma. La constante `STATUS_DELETED` et son libellé sont conservés pour l'affichage d'éventuelles lignes déjà soft-deletées en base.

## Test

1. Créer une carte grise.
2. La supprimer (mass-action « Supprimer » depuis la liste des cartes grises).
3. Vérifier que la ligne n'apparaît plus **et** qu'elle est bien absente de la table `llx_dolicar_registrationcertificatefr` (plus de ligne en statut `-1`).