### PR TITLE
#336 [RegistrationCertificateFr] add: delete button and confirmation on card

### DIFF
--- a/view/registrationcertificatefr/registrationcertificatefr_card.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_card.php
@@ -452,6 +452,11 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
 
     $formConfirm = '';
 
+    // Confirmation to delete
+    if ($action == 'delete') {
+        $formConfirm .= $form->formconfirm($_SERVER['PHP_SELF'] . '?id=' . $object->id, $langs->trans('Delete'), $langs->trans('ConfirmDeleteObject'), 'confirm_delete', '', 0, 1);
+    }
+
     // Call Hook formConfirm
     $parameters = ['formConfirm' => $formConfirm];
     $resHook    = $hookmanager->executeHooks('formConfirm', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
@@ -583,7 +588,8 @@ if ($object->id > 0 && (empty($action) || ($action != 'edit' && $action != 'crea
                 print dolGetButtonAction($displayButton, '', 'default', dol_buildpath('fichinter/card.php?action=create&socid=' . $object->fk_soc, 3), '', $permissiontoadd);
             }
 
-
+            $displayButton = $conf->browser->layout == 'classic' ? '<i class="fas fa-trash pictofixedwidth"></i>' . $langs->trans('Delete') : '<i class="fas fa-trash fa-2x"></i>';
+            print dolGetButtonAction($displayButton, '', 'delete', $_SERVER['PHP_SELF'] . '?id=' . $object->id . '&action=delete&token=' . newToken(), '', $permissiontodelete);
         }
         print '</div>';
     }


### PR DESCRIPTION
## Contexte

Refs #336

La fiche d'une carte grise (`registrationcertificatefr_card.php`) ne proposait **aucune action de suppression** : on ne pouvait supprimer une carte grise que via la mass-action de la liste.

> ℹ️ La mass-action « Supprimer » de la **liste** existe déjà (fournie par le template de liste générique Saturne dès que le droit `delete` est accordé) — aucun ajout nécessaire de ce côté.

## Correctif

Ajout sur la fiche de :

- un bouton **« Supprimer »** dans la barre d'actions (`tabsAction`), affiché uniquement si l'utilisateur a le droit `dolicar > registrationcertificatefr > delete` ;
- la **boîte de confirmation** correspondante (`formconfirm` → `confirm_delete`).

Le traitement réel est délégué au handler générique `core/actions_addupdatedelete.inc.php` déjà inclus par la fiche (qui appelle `$object->delete($user)` puis redirige vers la liste via `$backurlforlist`). Clés de traduction génériques du cœur (`Delete`, `ConfirmDeleteObject`) — aucune nouvelle clé à ajouter.

> 🔗 Couplé à #337 (PR #435) : une fois cette dernière mergée, le bouton déclenche une suppression **définitive** (hard delete).

## Test

1. Ouvrir la fiche d'une carte grise.
2. Cliquer sur **Supprimer** → la boîte de confirmation s'affiche.
3. Confirmer → message « Enregistrement supprimé » et redirection vers la liste ; la carte grise n'apparaît plus.
4. Vérifier qu'un utilisateur **sans** le droit `delete` ne voit pas le bouton.