### PR TITLE
#442 [PublicControl] add: show vehicle registration plate on public control card

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -432,6 +432,47 @@ class ActionsDoliCar
     }
 
     /**
+     * Overloading the printPublicControlLinkedObjectIdentity function : replacing the parent's function with the one below
+     *
+     * Replaces the linked object identity block of the public control card to show the vehicle
+     * registration plate prominently, keeping the lot/serial (VIN) as a secondary line.
+     *
+     * @param  array  $parameters Hook metadata (context, etc...)
+     * @param  object $object     Linked object (productlot expected)
+     * @return int                0 < on error, 0 on success, 1 to replace standard code
+     * @throws Exception
+     */
+    public function printPublicControlLinkedObjectIdentity(array $parameters, $object): int
+    {
+        global $langs;
+
+        if (strpos($parameters['context'], 'publiccontrol') === false || !is_object($object) || $object->element != 'productlot') {
+            return 0;
+        }
+
+        $registrationCertificateFr = new RegistrationCertificateFr($this->db);
+        $registrationCertificates  = $registrationCertificateFr->fetchAll('', '', 1, 0, ['customsql' => 't.fk_lot = ' . (int) $object->id]);
+        if (!is_array($registrationCertificates) || empty($registrationCertificates)) {
+            return 0;
+        }
+        $registrationCertificateFr = reset($registrationCertificates);
+
+        $langs->load('dolicar@dolicar');
+
+        $lotTitle = $parameters['linkedObjectInfoArray']['linkedObject']['title'] ?? '';
+        $lotValue = $parameters['linkedObjectInfoArray']['linkedObject']['name_field'] ?? '';
+
+        $out  = '<div class="information-type">' . $langs->transnoentities('RegistrationPlate') . '</div>';
+        $out .= '<div class="information-label size-l">' . dol_escape_htmltag($registrationCertificateFr->ref) . '</div>';
+        $out .= '<div class="information-type">' . $lotTitle . '</div>';
+        $out .= '<div class="information-label">' . $lotValue . '</div>';
+
+        $this->resprints = $out;
+
+        return 1; // replace standard code
+    }
+
+    /**
      * Overloading the saturneSetVarsFromFetchObj function : replacing the parent's function with the one below
      *
      * @param  array $parameters Hook metadata (context, etc...)
@@ -446,7 +487,7 @@ class ActionsDoliCar
             $conf->cache['control']  = null;
             $conf->cache['controls'] = [];
             $object->fetchObjectLinked(null, '', '', 'digiquali_control');
-            if (!is_array($object->linkedObjects['digiquali_control']) || empty($object->linkedObjects['digiquali_control'])) {
+            if (empty($object->linkedObjects['digiquali_control']) || !is_array($object->linkedObjects['digiquali_control'])) {
                 return 0;
             }
 

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -109,6 +109,7 @@ ListRegistrationcertificatefr   = Liste des cartes grises
 NewRegistrationcertificatefr    = Nouvelle carte grise
 ModifyRegistrationcertificatefr = Modifier la carte grise
 FindLicencePlateInRepertory     = Rechercher une plaque d'immatriculation
+RegistrationPlate               = Immatriculation
 
 # Fiels - Champs
 RegistrationNumber            = Numéro d'immatriculation (A)


### PR DESCRIPTION
## Changements
- Affichage de la plaque d'immatriculation du véhicule en évidence (gros) sur la carte de l'interface publique de contrôle (onglets « État : Lot/Série » et « Liste des contrôles »), via le hook `printPublicControlLinkedObjectIdentity`.
- Le numéro de Lot/Série (VIN) est conservé sous la plaque, en ligne secondaire.
- N'affecte que les `productlot` rattachés à une carte grise (`fk_lot`) ; sinon le comportement d'affichage par défaut est conservé.
- Ajout de la clé de langue `RegistrationPlate` (fr_FR).

## Fichiers modifiés
- class/actions_dolicar.class.php
- langs/fr_FR/dolicar.lang

## Dépendance
Nécessite le hook ajouté côté DigiQuali : Evarisk/digiquali#2440

## Issue
#442
