### PR TITLE
#448 [RegistrationCertificate] add: vehicle quick info, control interface link and linked objects amounts/filters

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -265,9 +265,20 @@ class ActionsDoliCar
         if (strpos($parameters['context'], 'registrationcertificatefrcard') !== false && !empty($object->fk_lot)) {
             $publicLogbookUrl = dol_buildpath('/custom/dolicar/public/agenda/public_vehicle_logbook.php', 1) . '?id=' . (int) $object->fk_lot . '&entity=' . (int) $conf->entity;
             $this->resprints  = '<div class="refidno">';
+            $this->resprints .= img_picto('', 'dolicar_color@dolicar', 'class="pictofixedwidth"');
             $this->resprints .= '<a href="' . dol_escape_htmltag($publicLogbookUrl) . '" target="_blank" class="dolicar-public-logbook-link">';
             $this->resprints .= '<i class="fas fa-globe"></i> ' . $langs->transnoentities('PublicVehicleLogBook');
             $this->resprints .= '</a>';
+
+            // Link to the DigiQuali public quality-control interface for the linked vehicle lot
+            if (isModEnabled('digiquali')) {
+                $trackId          = base64_encode(json_encode(['type' => 'productlot', 'id' => (int) $object->fk_lot]));
+                $publicControlUrl = dol_buildpath('/custom/digiquali/public/control/public_control_history.php', 1) . '?track_id=' . urlencode($trackId) . '&entity=' . (int) $conf->entity;
+                $this->resprints .= '<a href="' . dol_escape_htmltag($publicControlUrl) . '" target="_blank" class="dolicar-public-control-link marginleftonly">';
+                $this->resprints .= '<i class="fas fa-clipboard-check"></i> ' . $langs->transnoentities('QualityControlInterface');
+                $this->resprints .= '</a>';
+            }
+
             $this->resprints .= '</div>';
         }
 

--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -264,18 +264,17 @@ class ActionsDoliCar
 
         if (strpos($parameters['context'], 'registrationcertificatefrcard') !== false && !empty($object->fk_lot)) {
             $publicLogbookUrl = dol_buildpath('/custom/dolicar/public/agenda/public_vehicle_logbook.php', 1) . '?id=' . (int) $object->fk_lot . '&entity=' . (int) $conf->entity;
-            $this->resprints  = '<div class="refidno">';
-            $this->resprints .= img_picto('', 'dolicar_color@dolicar', 'class="pictofixedwidth"');
-            $this->resprints .= '<a href="' . dol_escape_htmltag($publicLogbookUrl) . '" target="_blank" class="dolicar-public-logbook-link">';
-            $this->resprints .= '<i class="fas fa-globe"></i> ' . $langs->transnoentities('PublicVehicleLogBook');
+            $this->resprints  = '<div class="refidno dolicar-banner-links">';
+            $this->resprints .= '<a href="' . dol_escape_htmltag($publicLogbookUrl) . '" target="_blank" class="dolicar-banner-link dolicar-public-logbook-link">';
+            $this->resprints .= img_picto('', 'dolicar_color@dolicar', 'class="dolicar-banner-logo"') . $langs->transnoentities('PublicVehicleLogBook');
             $this->resprints .= '</a>';
 
             // Link to the DigiQuali public quality-control interface for the linked vehicle lot
             if (isModEnabled('digiquali')) {
                 $trackId          = base64_encode(json_encode(['type' => 'productlot', 'id' => (int) $object->fk_lot]));
                 $publicControlUrl = dol_buildpath('/custom/digiquali/public/control/public_control_history.php', 1) . '?track_id=' . urlencode($trackId) . '&entity=' . (int) $conf->entity;
-                $this->resprints .= '<a href="' . dol_escape_htmltag($publicControlUrl) . '" target="_blank" class="dolicar-public-control-link marginleftonly">';
-                $this->resprints .= '<i class="fas fa-clipboard-check"></i> ' . $langs->transnoentities('QualityControlInterface');
+                $this->resprints .= '<a href="' . dol_escape_htmltag($publicControlUrl) . '" target="_blank" class="dolicar-banner-link dolicar-public-control-link">';
+                $this->resprints .= img_picto('', 'digiquali_color@digiquali', 'class="dolicar-banner-logo"') . $langs->transnoentities('QualityControlInterface');
                 $this->resprints .= '</a>';
             }
 

--- a/core/tpl/registrationcertificatefr_linked_objects.tpl.php
+++ b/core/tpl/registrationcertificatefr_linked_objects.tpl.php
@@ -23,9 +23,11 @@
 
 /**
  * The following vars must be defined :
- * Global   : $db, $langs
+ * Global   : $db, $langs, $conf
  * Variable : $fromProductLot
  */
+
+global $conf;
 
 // Load DoliCar libraries
 require_once __DIR__ . '/../../class/registrationcertificatefr.class.php';
@@ -39,45 +41,45 @@ if ($digiqualiEnabled) {
     require_once DOL_DOCUMENT_ROOT . '/custom/digiquali/class/sheet.class.php';
 }
 
-$colspanEmpty = $digiqualiEnabled ? 8 : 4;
+// Load commercial document classes to list linked invoices/proposals and sum their amounts
+$factureEnabled = isModEnabled('facture');
+$propalEnabled  = isModEnabled('propal');
+if ($factureEnabled) {
+    require_once DOL_DOCUMENT_ROOT . '/compta/facture/class/facture.class.php';
+}
+if ($propalEnabled) {
+    require_once DOL_DOCUMENT_ROOT . '/comm/propal/class/propal.class.php';
+}
 
-$out  = load_fiche_titre($langs->transnoentities('LinkedObjects'), '', 'dolicar_color@dolicar');
-$out .= '<table class="noborder centpercent">';
-$out .= '<tr class="liste_titre">';
-$out .= '<td>' . $langs->trans('ObjectType') . '</td>';
-$out .= '<td>' . $langs->trans('Object') . '</td>';
-if ($digiqualiEnabled) {
-    $out .= '<td>' . $langs->trans('Sheet') . '</td>';
-}
-$out .= '<td>' . $langs->trans('Mileage') . '</td>';
-$out .= '<td>' . $langs->trans('Date') . '</td>';
-if ($digiqualiEnabled) {
-    $out .= '<td>' . $langs->trans('Verdict') . '</td>';
-    $out .= '<td>' . $langs->trans('ControlDate') . '</td>';
-    $out .= '<td>' . $langs->trans('NextControlDate') . '</td>';
-}
-$out .= '</tr>';
+// Column count for the "no data" message (+1 for the amount column, always displayed)
+$colspanEmpty = ($digiqualiEnabled ? 8 : 4) + 1;
+
+$totalAmount = 0;
 
 /**
  * Helper : render a single linked object row
  *
- * @param CommonObject $linkedObject        The linked object to display
- * @param string       $linkedObjectElement The element type key (e.g. 'digiquali_control')
- * @param bool         $digiqualiEnabled    Whether DigiQuali module is active
- * @param Translate    $langs               Translation object
- * @return string                           HTML row string
+ * @param  CommonObject $linkedObject        The linked object to display
+ * @param  string       $linkedObjectElement The element type key (e.g. 'digiquali_control')
+ * @param  bool         $digiqualiEnabled    Whether DigiQuali module is active
+ * @param  Translate    $langs               Translation object
+ * @param  float        $totalAmount         Running total of amounts (passed by reference)
+ * @return string                            HTML row string
  */
-$renderLinkedObjectRow = static function ($linkedObject, string $linkedObjectElement, bool $digiqualiEnabled, $langs): string {
-    global $db;
-    $isControl = ($linkedObjectElement === 'digiquali_control');
-    $isSurvey  = ($linkedObjectElement === 'digiquali_survey');
+$renderLinkedObjectRow = static function ($linkedObject, string $linkedObjectElement, bool $digiqualiEnabled, $langs, &$totalAmount): string {
+    global $conf, $db;
+    $isControl       = ($linkedObjectElement === 'digiquali_control');
+    $isSurvey        = ($linkedObjectElement === 'digiquali_survey');
+    $isCommercialDoc = in_array($linkedObjectElement, ['facture', 'propal', 'commande'], true);
 
-    $row  = '<tr>';
+    $verdictValue = $isControl ? (int) $linkedObject->verdict : '';
+
+    $row  = '<tr class="dolicar-linked-object-row" data-verdict="' . $verdictValue . '">';
     $row .= '<td class="nowrap">' . $langs->transnoentities(ucfirst($linkedObjectElement)) . '</td>';
     $row .= '<td>' . $linkedObject->getNomUrl(1) . '</td>';
     if ($digiqualiEnabled) {
         if ($isControl || $isSurvey) {
-            $sheet = new Sheet($db);
+            $sheet     = new Sheet($db);
             $sheetLink = '';
             if (!empty($linkedObject->fk_sheet) && $sheet->fetch($linkedObject->fk_sheet) > 0) {
                 $sheetLink = $sheet->getNomUrl(1) . (!empty($sheet->label) ? ' - ' . $sheet->label : '');
@@ -87,7 +89,7 @@ $renderLinkedObjectRow = static function ($linkedObject, string $linkedObjectEle
             $row .= '<td></td>';
         }
     }
-    $row .= '<td>' . (!$isControl && !$isSurvey ? $linkedObject->array_options['options_mileage'] : '') . '</td>';
+    $row .= '<td>' . (!$isControl && !$isSurvey && !$isCommercialDoc ? ($linkedObject->array_options['options_mileage'] ?? '') : '') . '</td>';
     $row .= '<td>' . dol_print_date($linkedObject->date_creation, 'dayhour') . '</td>';
     if ($digiqualiEnabled) {
         if ($isControl) {
@@ -99,6 +101,13 @@ $renderLinkedObjectRow = static function ($linkedObject, string $linkedObjectEle
         } else {
             $row .= '<td></td><td></td><td></td>';
         }
+    }
+    // Amount (incl. tax) column: only commercial documents carry an amount; it feeds the grand total
+    if ($isCommercialDoc && isset($linkedObject->total_ttc)) {
+        $totalAmount += (float) $linkedObject->total_ttc;
+        $row .= '<td class="right nowrap">' . price($linkedObject->total_ttc, 0, $langs, 1, -1, -1, $conf->currency) . '</td>';
+    } else {
+        $row .= '<td class="right"></td>';
     }
     $row .= '</tr>';
     return $row;
@@ -119,7 +128,7 @@ if (!empty($registrationCertificate->linkedObjects)) {
             if (isset($linkedObject->status) && $linkedObject->status == -1) {
                 continue;
             }
-            $rows[$linkedObjectElement . '_' . $linkedObjectId] = $renderLinkedObjectRow($linkedObject, $linkedObjectElement, $digiqualiEnabled, $langs);
+            $rows[$linkedObjectElement . '_' . $linkedObjectId] = $renderLinkedObjectRow($linkedObject, $linkedObjectElement, $digiqualiEnabled, $langs, $totalAmount);
         }
     }
 }
@@ -138,15 +147,85 @@ if ($digiqualiEnabled && $registrationCertificate->fk_lot > 0) {
                 }
                 $key = $elementType . '_' . $linkedObjectId;
                 if (!isset($rows[$key])) {
-                    $rows[$key] = $renderLinkedObjectRow($linkedObject, $elementType, $digiqualiEnabled, $langs);
+                    $rows[$key] = $renderLinkedObjectRow($linkedObject, $elementType, $digiqualiEnabled, $langs, $totalAmount);
                 }
             }
         }
     }
 }
 
+// Invoices and proposals linked through their "registrationcertificatefr" extrafield (set by the New invoice/proposal buttons)
+$commercialDocSources = [];
+if ($factureEnabled) {
+    $commercialDocSources['facture'] = ['table' => 'facture_extrafields', 'class' => 'Facture'];
+}
+if ($propalEnabled) {
+    $commercialDocSources['propal'] = ['table' => 'propal_extrafields', 'class' => 'Propal'];
+}
+foreach ($commercialDocSources as $elementType => $source) {
+    $sql   = 'SELECT fk_object FROM ' . MAIN_DB_PREFIX . $source['table'] . ' WHERE registrationcertificatefr = ' . (int) $registrationCertificate->id;
+    $resql = $db->query($sql);
+    if ($resql) {
+        while ($obj = $db->fetch_object($resql)) {
+            $key = $elementType . '_' . $obj->fk_object;
+            if (isset($rows[$key])) {
+                continue;
+            }
+            $commercialDoc = new $source['class']($db);
+            if ($commercialDoc->fetch($obj->fk_object) > 0) {
+                $rows[$key] = $renderLinkedObjectRow($commercialDoc, $elementType, $digiqualiEnabled, $langs, $totalAmount);
+            }
+        }
+        $db->free($resql);
+    }
+}
+
+$out = load_fiche_titre($langs->transnoentities('LinkedObjects'), '', 'dolicar_color@dolicar');
+
+// Search / filter toolbar (client-side filtering handled by js/modules/linkedObjects.js)
+if (!empty($rows)) {
+    $out .= '<div class="dolicar-linked-objects-toolbar">';
+    $out .= '<input type="text" class="dolicar-linked-objects-search" placeholder="' . dol_escape_htmltag($langs->trans('Search')) . '">';
+    if ($digiqualiEnabled) {
+        $control       = new Control($db);
+        $verdictValues = $control->fields['verdict']['arrayofkeyval'] ?? [];
+        $out .= '<select class="dolicar-linked-objects-verdict-filter flat">';
+        $out .= '<option value="">' . $langs->trans('Verdict') . '</option>';
+        foreach ($verdictValues as $verdictKey => $verdictLabel) {
+            $out .= '<option value="' . (int) $verdictKey . '">' . $langs->trans($verdictLabel) . '</option>';
+        }
+        if (!isset($verdictValues[0])) {
+            $out .= '<option value="0">N/A</option>';
+        }
+        $out .= '</select>';
+    }
+    $out .= '</div>';
+}
+
+$out .= '<table class="noborder centpercent dolicar-linked-objects-table">';
+$out .= '<tr class="liste_titre">';
+$out .= '<td>' . $langs->trans('ObjectType') . '</td>';
+$out .= '<td>' . $langs->trans('Object') . '</td>';
+if ($digiqualiEnabled) {
+    $out .= '<td>' . $langs->trans('Sheet') . '</td>';
+}
+$out .= '<td>' . $langs->trans('Mileage') . '</td>';
+$out .= '<td>' . $langs->trans('Date') . '</td>';
+if ($digiqualiEnabled) {
+    $out .= '<td>' . $langs->trans('Verdict') . '</td>';
+    $out .= '<td>' . $langs->trans('ControlDate') . '</td>';
+    $out .= '<td>' . $langs->trans('NextControlDate') . '</td>';
+}
+$out .= '<td class="right">' . $langs->trans('AmountTTC') . '</td>';
+$out .= '</tr>';
+
 if (!empty($rows)) {
     $out .= implode('', $rows);
+    // Grand total of the linked commercial documents (invoices + proposals)
+    $out .= '<tr class="liste_total">';
+    $out .= '<td class="right" colspan="' . ($colspanEmpty - 1) . '">' . $langs->trans('Total') . '</td>';
+    $out .= '<td class="right nowrap">' . price($totalAmount, 0, $langs, 1, -1, -1, $conf->currency) . '</td>';
+    $out .= '</tr>';
 } else {
     $out .= '<tr><td colspan="' . $colspanEmpty . '">' . $langs->trans('NoLinkedObjectsToPrint') . '</td></tr>';
 }

--- a/core/tpl/registrationcertificatefr_linked_objects.tpl.php
+++ b/core/tpl/registrationcertificatefr_linked_objects.tpl.php
@@ -182,42 +182,58 @@ foreach ($commercialDocSources as $elementType => $source) {
 
 $out = load_fiche_titre($langs->transnoentities('LinkedObjects'), '', 'dolicar_color@dolicar');
 
-// Search / filter toolbar (client-side filtering handled by js/modules/linkedObjects.js)
+// Column definitions: keep the header, the per-column search row and the data cells aligned
+$columns = [];
+$columns[] = ['label' => $langs->trans('ObjectType')];
+$columns[] = ['label' => $langs->trans('Object')];
+if ($digiqualiEnabled) {
+    $columns[] = ['label' => $langs->trans('Sheet')];
+}
+$columns[] = ['label' => $langs->trans('Mileage')];
+$columns[] = ['label' => $langs->trans('Date')];
+if ($digiqualiEnabled) {
+    $columns[] = ['label' => $langs->trans('Verdict'), 'filter' => 'verdict'];
+    $columns[] = ['label' => $langs->trans('ControlDate')];
+    $columns[] = ['label' => $langs->trans('NextControlDate')];
+}
+$columns[] = ['label' => $langs->trans('AmountTTC'), 'align' => 'right'];
+
+$out .= '<table class="noborder centpercent dolicar-linked-objects-table">';
+
+// Header row
+$out .= '<tr class="liste_titre">';
+foreach ($columns as $column) {
+    $out .= '<td' . (($column['align'] ?? '') === 'right' ? ' class="right"' : '') . '>' . $column['label'] . '</td>';
+}
+$out .= '</tr>';
+
+// Per-column search row (native Dolibarr style, client-side filtering handled by js/modules/linkedObjects.js)
 if (!empty($rows)) {
-    $out .= '<div class="dolicar-linked-objects-toolbar">';
-    $out .= '<input type="text" class="dolicar-linked-objects-search" placeholder="' . dol_escape_htmltag($langs->trans('Search')) . '">';
+    $verdictValues = [];
     if ($digiqualiEnabled) {
         $control       = new Control($db);
         $verdictValues = $control->fields['verdict']['arrayofkeyval'] ?? [];
-        $out .= '<select class="dolicar-linked-objects-verdict-filter flat">';
-        $out .= '<option value="">' . $langs->trans('Verdict') . '</option>';
-        foreach ($verdictValues as $verdictKey => $verdictLabel) {
-            $out .= '<option value="' . (int) $verdictKey . '">' . $langs->trans($verdictLabel) . '</option>';
-        }
-        if (!isset($verdictValues[0])) {
-            $out .= '<option value="0">N/A</option>';
-        }
-        $out .= '</select>';
     }
-    $out .= '</div>';
+    $out .= '<tr class="liste_titre">';
+    foreach ($columns as $colIndex => $column) {
+        $out .= '<td' . (($column['align'] ?? '') === 'right' ? ' class="right"' : '') . '>';
+        if (($column['filter'] ?? '') === 'verdict') {
+            $out .= '<select class="dolicar-linked-objects-verdict-filter flat maxwidth100">';
+            $out .= '<option value="">&nbsp;</option>';
+            foreach ($verdictValues as $verdictKey => $verdictLabel) {
+                $out .= '<option value="' . (int) $verdictKey . '">' . $langs->trans($verdictLabel) . '</option>';
+            }
+            if (!isset($verdictValues[0])) {
+                $out .= '<option value="0">N/A</option>';
+            }
+            $out .= '</select>';
+        } else {
+            $out .= '<input type="text" class="dolicar-linked-objects-filter flat maxwidth100" data-col="' . $colIndex . '">';
+        }
+        $out .= '</td>';
+    }
+    $out .= '</tr>';
 }
-
-$out .= '<table class="noborder centpercent dolicar-linked-objects-table">';
-$out .= '<tr class="liste_titre">';
-$out .= '<td>' . $langs->trans('ObjectType') . '</td>';
-$out .= '<td>' . $langs->trans('Object') . '</td>';
-if ($digiqualiEnabled) {
-    $out .= '<td>' . $langs->trans('Sheet') . '</td>';
-}
-$out .= '<td>' . $langs->trans('Mileage') . '</td>';
-$out .= '<td>' . $langs->trans('Date') . '</td>';
-if ($digiqualiEnabled) {
-    $out .= '<td>' . $langs->trans('Verdict') . '</td>';
-    $out .= '<td>' . $langs->trans('ControlDate') . '</td>';
-    $out .= '<td>' . $langs->trans('NextControlDate') . '</td>';
-}
-$out .= '<td class="right">' . $langs->trans('AmountTTC') . '</td>';
-$out .= '</tr>';
 
 if (!empty($rows)) {
     $out .= implode('', $rows);

--- a/css/scss/pages/_registrationcertificatefr-card.scss
+++ b/css/scss/pages/_registrationcertificatefr-card.scss
@@ -1,11 +1,16 @@
-.dolicar-public-logbook-link {
+.dolicar-banner-links {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+}
+
+.dolicar-banner-link {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
+    gap: 5px;
     padding: 2px 8px;
-    background: #e8f0fd;
-    color: #1a5cdc !important;
-    border: 1px solid #c0d4f7;
+    border: 1px solid transparent;
     border-radius: 4px;
     font-size: 11px;
     font-weight: 600;
@@ -13,13 +18,38 @@
     vertical-align: middle;
     line-height: 1.6;
 
-    i { font-size: 10px; }
+    .dolicar-banner-logo {
+        height: 13px;
+        width: auto;
+        vertical-align: middle;
+    }
+
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+.dolicar-public-logbook-link {
+    background: #e8f0fd;
+    color: #1a5cdc !important;
+    border-color: #c0d4f7;
 
     &:hover {
         background: #d0e2fb;
         border-color: #90b8f0;
-        text-decoration: none;
         color: #1a5cdc !important;
+    }
+}
+
+.dolicar-public-control-link {
+    background: #fbe9ec;
+    color: #b03651 !important;
+    border-color: #f0c2c9;
+
+    &:hover {
+        background: #f6d6dc;
+        border-color: #e3a3ae;
+        color: #b03651 !important;
     }
 }
 

--- a/css/scss/pages/_registrationcertificatefr-card.scss
+++ b/css/scss/pages/_registrationcertificatefr-card.scss
@@ -42,14 +42,15 @@
 }
 
 .dolicar-public-control-link {
-    background: #fbe9ec;
-    color: #b03651 !important;
-    border-color: #f0c2c9;
+    // DigiQuali public interface palette ($color__public-secondary / $color__public-primary)
+    background: #bdceea;
+    color: #002475 !important;
+    border-color: #9db5da;
 
     &:hover {
-        background: #f6d6dc;
-        border-color: #e3a3ae;
-        color: #b03651 !important;
+        background: #aac1e3;
+        border-color: #002475;
+        color: #002475 !important;
     }
 }
 

--- a/css/scss/pages/_registrationcertificatefr-card.scss
+++ b/css/scss/pages/_registrationcertificatefr-card.scss
@@ -29,7 +29,8 @@
     }
 }
 
-.dolicar-public-logbook-link {
+.dolicar-public-logbook-link,
+.dolicar-public-control-link {
     background: #e8f0fd;
     color: #1a5cdc !important;
     border-color: #c0d4f7;
@@ -38,19 +39,6 @@
         background: #d0e2fb;
         border-color: #90b8f0;
         color: #1a5cdc !important;
-    }
-}
-
-.dolicar-public-control-link {
-    // DigiQuali public interface palette ($color__public-secondary / $color__public-primary)
-    background: #bdceea;
-    color: #002475 !important;
-    border-color: #9db5da;
-
-    &:hover {
-        background: #aac1e3;
-        border-color: #002475;
-        color: #002475 !important;
     }
 }
 

--- a/js/modules/linkedObjects.js
+++ b/js/modules/linkedObjects.js
@@ -1,0 +1,87 @@
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    js/modules/linkedObjects.js
+ * \ingroup dolicar
+ * \brief   JavaScript module to search/filter the registration certificate linked objects table
+ */
+
+'use strict';
+
+/**
+ * Init linkedObjects JS
+ *
+ * @memberof DoliCar_LinkedObjects
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @type {Object}
+ */
+window.dolicar.linkedObjects = {};
+
+/**
+ * LinkedObjects init
+ *
+ * @memberof DoliCar_LinkedObjects
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @return {void}
+ */
+window.dolicar.linkedObjects.init = function() {
+  window.dolicar.linkedObjects.event();
+};
+
+/**
+ * LinkedObjects event — bind delegated handlers
+ *
+ * @memberof DoliCar_LinkedObjects
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @return {void}
+ */
+window.dolicar.linkedObjects.event = function() {
+  $(document).on('input', '.dolicar-linked-objects-search', window.dolicar.linkedObjects.filter);
+  $(document).on('change', '.dolicar-linked-objects-verdict-filter', window.dolicar.linkedObjects.filter);
+};
+
+/**
+ * Filter the linked objects table rows from the search text and the verdict select
+ *
+ * @memberof DoliCar_LinkedObjects
+ *
+ * @since   1.4.0
+ * @version 1.4.0
+ *
+ * @return {void}
+ */
+window.dolicar.linkedObjects.filter = function() {
+  var search  = ($('.dolicar-linked-objects-search').val() || '').toLowerCase();
+  var verdict = $('.dolicar-linked-objects-verdict-filter').val() || '';
+
+  $('.dolicar-linked-objects-table .dolicar-linked-object-row').each(function() {
+    var $row         = $(this);
+    var textMatch    = $row.text().toLowerCase().indexOf(search) !== -1;
+    var verdictMatch = verdict === '' || String($row.attr('data-verdict')) === verdict;
+
+    $row.toggle(textMatch && verdictMatch);
+  });
+};

--- a/js/modules/linkedObjects.js
+++ b/js/modules/linkedObjects.js
@@ -59,12 +59,13 @@ window.dolicar.linkedObjects.init = function() {
  * @return {void}
  */
 window.dolicar.linkedObjects.event = function() {
-  $(document).on('input', '.dolicar-linked-objects-search', window.dolicar.linkedObjects.filter);
+  $(document).on('input', '.dolicar-linked-objects-filter', window.dolicar.linkedObjects.filter);
   $(document).on('change', '.dolicar-linked-objects-verdict-filter', window.dolicar.linkedObjects.filter);
 };
 
 /**
- * Filter the linked objects table rows from the search text and the verdict select
+ * Filter the linked objects table rows from the per-column search inputs and the verdict select.
+ * A row is shown only when every active filter matches its own column (native Dolibarr list behaviour).
  *
  * @memberof DoliCar_LinkedObjects
  *
@@ -74,14 +75,30 @@ window.dolicar.linkedObjects.event = function() {
  * @return {void}
  */
 window.dolicar.linkedObjects.filter = function() {
-  var search  = ($('.dolicar-linked-objects-search').val() || '').toLowerCase();
-  var verdict = $('.dolicar-linked-objects-verdict-filter').val() || '';
+  var $table         = $('.dolicar-linked-objects-table');
+  var $textFilters   = $table.find('.dolicar-linked-objects-filter');
+  var verdict        = $table.find('.dolicar-linked-objects-verdict-filter').val() || '';
 
-  $('.dolicar-linked-objects-table .dolicar-linked-object-row').each(function() {
-    var $row         = $(this);
-    var textMatch    = $row.text().toLowerCase().indexOf(search) !== -1;
-    var verdictMatch = verdict === '' || String($row.attr('data-verdict')) === verdict;
+  $table.find('.dolicar-linked-object-row').each(function() {
+    var $row = $(this);
+    var show = true;
 
-    $row.toggle(textMatch && verdictMatch);
+    $textFilters.each(function() {
+      var value = ($(this).val() || '').toLowerCase();
+      if (value === '') {
+        return;
+      }
+      var column   = parseInt($(this).attr('data-col'), 10);
+      var cellText = $row.children('td').eq(column).text().toLowerCase();
+      if (cellText.indexOf(value) === -1) {
+        show = false;
+      }
+    });
+
+    if (show && verdict !== '' && String($row.attr('data-verdict')) !== verdict) {
+      show = false;
+    }
+
+    $row.toggle(show);
   });
 };

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -110,6 +110,7 @@ NewRegistrationcertificatefr    = Nouvelle carte grise
 ModifyRegistrationcertificatefr = Modifier la carte grise
 FindLicencePlateInRepertory     = Rechercher une plaque d'immatriculation
 RegistrationPlate               = Immatriculation
+QualityControlInterface         = Interface de contrôle qualité
 
 # Fiels - Champs
 RegistrationNumber            = Numéro d'immatriculation (A)


### PR DESCRIPTION
## Changements
Mise en œuvre des points nets de #448 sur la fiche carte grise.

### Bannière
- Ajout du logo DoliCar.
- Ajout d'un lien direct vers l'interface publique de contrôle qualité du véhicule (réutilise le `track_id` du lot), à côté du « Carnet de bord publique du véhicule ».

### Tableau « Objets liés »
- Nouvelle colonne « Montant TTC » : affiche le total TTC des factures et devis liés à la carte grise, avec une ligne de **total** en bas.
- Barre de **recherche** (texte) + **filtre par verdict** (filtrage côté client, module `js/modules/linkedObjects.js`).

## Hors périmètre (à traiter séparément)
- Point 2 (type d'événement + rappel agenda) : reporté, à cadrer dans une issue dédiée.
- Liaison directe vers la pièce jointe (mentionnée dans le titre) : non incluse.

## Fichiers modifiés
- class/actions_dolicar.class.php
- core/tpl/registrationcertificatefr_linked_objects.tpl.php
- js/modules/linkedObjects.js (nouveau)
- langs/fr_FR/dolicar.lang

## Note build
`js/dolicar.min.js` n'est pas commité manuellement : il sera recompilé par la CI au merge sur develop.

## Issue
#448
