### PR TITLE
#443 [PublicVehicleLogBook] add: report a problem (comment, photo, voice) emailed to the manager

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -72,6 +72,13 @@ if ($action == 'update_warehouse') {
     $action = 'edit';
 }
 
+if ($action == 'update_problem_report') {
+    $email = GETPOST('DOLICAR_PROBLEM_REPORT_EMAIL', 'alphanohtml');
+    dolibarr_set_const($db, 'DOLICAR_PROBLEM_REPORT_EMAIL', $email, 'chaine', 0, '', $conf->entity);
+    setEventMessages($langs->trans('SetupSaved'), null, 'mesgs');
+    $action = 'edit';
+}
+
 if ($action == 'update') {
 	$error = 0;
 
@@ -208,6 +215,35 @@ print '</td>';
 print '<td class="center">';
 $formproduct = new FormProduct($db);
 print $formproduct->selectWarehouses(getDolGlobalInt('DOLICAR_DEFAULT_WAREHOUSE_ID'), 'DOLICAR_DEFAULT_WAREHOUSE_ID', '', 1, 0, 0, '', 0, 0, [], 'minwidth300');
+print '</td>';
+print '</tr>';
+print '</table>';
+
+print '<br><div class="center">';
+print '<input class="button button-save" type="submit" value="' . $langs->trans('Save') . '">';
+print '</div>';
+print '</form>';
+
+// Problem report email section (issue #443)
+print '<br>';
+print load_fiche_titre($langs->transnoentities('ProblemReportConfig'), '', '');
+
+print '<form method="POST" action="' . $_SERVER["PHP_SELF"] . '">';
+print '<input type="hidden" name="token" value="' . newToken() . '">';
+print '<input type="hidden" name="action" value="update_problem_report">';
+
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre">';
+print '<td>' . $langs->transnoentities('Parameters') . '</td>';
+print '<td class="center">' . $langs->transnoentities('Value') . '</td>';
+print '</tr>';
+
+print '<tr class="oddeven">';
+print '<td class="nowraponall">';
+print $langs->transnoentities('ProblemReportEmail') . '<br><span class="opacitymedium">' . $langs->transnoentities('ProblemReportEmailDesc') . '</span>';
+print '</td>';
+print '<td class="center">';
+print '<input class="flat minwidth300" type="email" name="DOLICAR_PROBLEM_REPORT_EMAIL" value="' . dol_escape_htmltag(getDolGlobalString('DOLICAR_PROBLEM_REPORT_EMAIL')) . '" placeholder="responsable@example.com">';
 print '</td>';
 print '</tr>';
 print '</table>';

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -222,7 +222,7 @@ if (!empty($eventsList)) {
         $out .= '<td class="nowrap">' . $badge . '</td>';
         $out .= '<td class="center nowraponall">' . dol_print_date($evt->datep, 'day') . '</td>';
         $out .= '<td class="center">' . ($km > 0 ? price($km, 0, '', 1, 0) . ' km' : '') . '</td>';
-        $out .= '<td>' . dol_escape_htmltag((string) $evt->note_private) . '</td>';
+        $out .= '<td>' . nl2br(dol_escape_htmltag((string) $evt->note_private)) . '</td>';
         $out .= '<td class="center nowraponall">' . $userStr . '</td>';
         $out .= '<td>' . $linkedHtml . '</td>';
         $out .= '</tr>';

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -519,10 +519,16 @@
     .dolicar-problem-media-row {
       display: flex;
       align-items: center;
-      gap: 18px;
+      gap: 14px;
       flex-wrap: wrap;
 
       .linked-medias { margin: 0; }
+
+      // Data-only holders: collapse so they don't introduce a flex gap
+      .fast-upload-options { display: none; }
+      // Empty photo gallery placeholder otherwise pushes the audio buttons away
+      .saturne-media-gallery:empty { display: none; }
+      .saturne-media-upload-block { gap: 0; }
 
       // pico.css forces bare <button> to display:block / width:100% / coloured bg,
       // which breaks the Saturne media block icon buttons — restore them here.

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -97,6 +97,7 @@
 
       &--depart { background: #1571d3; color: #fff; }
       &--retour { background: #16a34a; color: #fff; }
+      &--probleme { background: #f59e0b; color: #fff; }
     }
 
     // ── Back button ──────────────────────────────────────────────────────
@@ -420,6 +421,15 @@
         }
       }
 
+      &--probleme {
+        border-color: #f59e0b;
+
+        .plv2-action-btn__icon {
+          background: #fef3c7;
+          color: #d97706;
+        }
+      }
+
       &--disabled {
         opacity: 0.4;
         cursor: not-allowed;
@@ -504,6 +514,15 @@
       }
 
       textarea { resize: vertical; }
+    }
+
+    .dolicar-problem-media-row {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      flex-wrap: wrap;
+
+      .linked-medias { margin: 0; }
     }
 
     .plv2-form-row {

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -532,11 +532,19 @@
         margin-bottom: 0;
       }
 
-      .saturne-media-btn {
+      .saturne-media-btn,
+      .saturne-upload-label {
         width: 48px;
         min-width: 48px;
         height: 48px;
+        margin: 0;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         border-radius: 10px;
+
+        i { font-size: 18px; }
       }
     }
 

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -523,6 +523,21 @@
       flex-wrap: wrap;
 
       .linked-medias { margin: 0; }
+
+      // pico.css forces bare <button> to display:block / width:100% / coloured bg,
+      // which breaks the Saturne media block icon buttons — restore them here.
+      button {
+        width: auto;
+        min-width: 0;
+        margin-bottom: 0;
+      }
+
+      .saturne-media-btn {
+        width: 48px;
+        min-width: 48px;
+        height: 48px;
+        border-radius: 10px;
+      }
     }
 
     .plv2-form-row {

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -530,6 +530,11 @@
       .saturne-media-gallery:empty { display: none; }
       .saturne-media-upload-block { gap: 0; }
 
+      // Saturne's audio container adds vertical padding/margin — drop it so the
+      // audio buttons sit on the same baseline as the photo button.
+      [id$="master-media-row-container-audio"] { padding: 0; }
+      .saturne-audio-controls { margin-top: 0; }
+
       // pico.css forces bare <button> to display:block / width:100% / coloured bg,
       // which breaks the Saturne media block icon buttons — restore them here.
       button {

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -112,6 +112,22 @@ FindLicencePlateInRepertory     = Rechercher une plaque d'immatriculation
 RegistrationPlate               = Immatriculation
 QualityControlInterface         = Interface de contrôle qualité
 
+# Public vehicle logbook - Signaler un problème
+ReportProblem                   = Signaler un problème
+ReportProblemSub                = Photo, commentaire, vocal
+DescribeProblem                 = Décrivez le problème rencontré
+PhotoAndVoiceMemo               = Photo et mémo vocal
+SendReport                      = Envoyer le signalement
+ProblemReportSent               = Signalement envoyé
+ProblemReportSentDesc           = Le responsable a été prévenu par email.
+ProblemReportedOnVehicle        = Problème signalé sur le véhicule %s
+ProblemReportEmailSubject       = Problème signalé - véhicule %s
+ProblemReportEmailIntro         = Un problème a été signalé sur le véhicule %s via le carnet de bord public.
+AccessVehicleSheet              = Accéder à la fiche du véhicule
+ProblemReportConfig             = Signalement de problème
+ProblemReportEmail              = Email du responsable
+ProblemReportEmailDesc          = Adresse à laquelle les signalements de problème du carnet de bord public sont envoyés. Si vide, l'email de la société est utilisé.
+
 # Fiels - Champs
 RegistrationNumber            = Numéro d'immatriculation (A)
 FirstRegistrationDate         = Date de la première immatriculation (B)

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -114,6 +114,7 @@ QualityControlInterface         = Interface de contrôle qualité
 
 # Public vehicle logbook - Signaler un problème
 ReportProblem                   = Signaler un problème
+ReportedProblem                 = Problème signalé
 ReportProblemSub                = Photo, commentaire, vocal
 DescribeProblem                 = Décrivez le problème rencontré
 PhotoAndVoiceMemo               = Photo et mémo vocal

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -151,6 +151,11 @@ if ($isModEnabledDigiquali) {
     }
 }
 
+// Problem report (issue #443): photo/voice are uploaded to a per-session temp dir keyed by an upload token
+require_once __DIR__ . '/../../../saturne/lib/medias.lib.php';
+$problemUploadContext = 'dolicar_problem_report_' . $id;
+$problemUploadSubDir  = 'problem_report/' . saturne_get_upload_token($problemUploadContext);
+
 /*
  * Actions
  */
@@ -162,6 +167,120 @@ if ($resHook < 0) {
 }
 
 if (empty($resHook)) {
+    // Problem report — photo upload posted by the Saturne media block (issue #443)
+    if ($action == 'uploadPhoto' && !empty($conf->global->MAIN_UPLOAD_DOC)) {
+        $uploadSubDir = GETPOST('sub_dir', 'alpha');
+        if (!empty($uploadSubDir) && strpos($uploadSubDir, '..') === false) {
+            $uploadDir = $conf->dolicar->dir_output . '/' . $uploadSubDir;
+            if (!dol_is_dir($uploadDir)) {
+                dol_mkdir($uploadDir);
+            }
+
+            $invalidFile   = false;
+            $uploadedFiles = isset($_FILES['userfile']) ? $_FILES['userfile'] : [];
+            if (!empty($uploadedFiles['tmp_name'])) {
+                $tmpNames = is_array($uploadedFiles['tmp_name']) ? $uploadedFiles['tmp_name'] : [$uploadedFiles['tmp_name']];
+                foreach ($tmpNames as $tmpName) {
+                    if (empty($tmpName)) {
+                        continue;
+                    }
+                    $finfo    = new finfo(FILEINFO_MIME_TYPE);
+                    $mimeType = $finfo->file($tmpName);
+                    if (strpos($mimeType, 'image/') !== 0) {
+                        $invalidFile = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!$invalidFile) {
+                dol_add_file_process($uploadDir, 0, 1, 'userfile', '', null, '', 1);
+            }
+        }
+    }
+
+    // Problem report — voice memo upload posted by the Saturne media block (issue #443)
+    if ($action == 'add_audio') {
+        $uploadSubDir = GETPOST('sub_dir', 'alpha');
+        if (!empty($_FILES['audio']['tmp_name']) && !empty($uploadSubDir) && strpos($uploadSubDir, '..') === false) {
+            $uploadDir = $conf->dolicar->dir_output . '/' . $uploadSubDir;
+            if (!dol_is_dir($uploadDir)) {
+                dol_mkdir($uploadDir);
+            }
+            $destFile = $uploadDir . '/' . dol_print_date(dol_now(), 'dayhourlog') . '_audio.wav';
+            move_uploaded_file($_FILES['audio']['tmp_name'], $destFile);
+        }
+    }
+
+    // Problem report — final submission: create the event, attach the media and email the manager (issue #443)
+    if ($action == 'report_problem') {
+        $comment = GETPOST('problem_comment', 'restricthtml');
+
+        $photoFiles = saturne_get_media_files('dolicar', $problemUploadSubDir, '', '', ['type' => 'image']);
+        $audioFiles = saturne_get_media_files('dolicar', $problemUploadSubDir, '', '', ['type' => 'audio']);
+
+        // Trace the problem as an event on the vehicle lot (visible in the vehicle history)
+        $problemAction               = new ActionComm($db);
+        $problemAction->elementtype  = $productLot->element;
+        $problemAction->type_code    = 'AC_OTH';
+        $problemAction->code         = 'AC_' . strtoupper($productLot->element) . '_REPORT_PROBLEM';
+        $problemAction->fk_element   = $productLot->id;
+        $problemAction->datep        = dol_now();
+        $problemAction->percentage   = -1;
+        $problemAction->userownerid  = 0;
+        $problemAction->label        = $langs->transnoentities('ProblemReportedOnVehicle', $registrationCertificateFR->a_registration_number);
+        $problemAction->note_private = (!empty($_SERVER['REMOTE_ADDR']) ? $langs->transnoentities('IPAddress') . ' : ' . $_SERVER['REMOTE_ADDR'] . '<br>' : '');
+        $problemAction->note_private .= $langs->transnoentities('Comment') . ' : ' . $comment;
+        $problemActionID              = $problemAction->create($user);
+
+        // Move the uploaded media from the temp dir to a permanent location keyed by the event
+        $finalDir = $conf->dolicar->dir_output . '/problem_report/' . ($problemActionID > 0 ? (int) $problemActionID : dol_print_date(dol_now(), 'dayhourlog'));
+        if (!dol_is_dir($finalDir)) {
+            dol_mkdir($finalDir);
+        }
+        $attachmentPaths = [];
+        $attachmentNames = [];
+        $attachmentMimes = [];
+        foreach (array_merge($photoFiles, $audioFiles) as $mediaFile) {
+            $destPath = $finalDir . '/' . $mediaFile['name'];
+            if (dol_move($mediaFile['fullname'], $destPath, 0, 1, 0, 0)) {
+                $attachmentPaths[] = $destPath;
+                $attachmentNames[] = $mediaFile['name'];
+                $attachmentMimes[] = dol_mimetype($mediaFile['name']);
+            }
+        }
+
+        // Email the manager
+        require_once DOL_DOCUMENT_ROOT . '/core/class/CMailFile.class.php';
+        $sendTo = getDolGlobalString('DOLICAR_PROBLEM_REPORT_EMAIL');
+        if (empty($sendTo)) {
+            $sendTo = getDolGlobalString('MAIN_INFO_SOCIETE_MAIL');
+        }
+        if (!empty($sendTo)) {
+            $from        = getDolGlobalString('MAIN_MAIL_EMAIL_FROM');
+            $vehicleLink = dol_buildpath('/custom/dolicar/view/registrationcertificatefr/registrationcertificatefr_card.php', 2) . '?id=' . (int) $registrationCertificateFR->id;
+            $subject     = $langs->transnoentities('ProblemReportEmailSubject', $registrationCertificateFR->a_registration_number);
+
+            $body  = '<p>' . $langs->transnoentities('ProblemReportEmailIntro', $registrationCertificateFR->a_registration_number) . '</p>';
+            $body .= '<ul>';
+            $body .= '<li>' . $langs->transnoentities('RegistrationPlate') . ' : <strong>' . dol_escape_htmltag($registrationCertificateFR->a_registration_number) . '</strong></li>';
+            $body .= '<li>' . $langs->transnoentities('Vehicle') . ' : ' . dol_escape_htmltag($registrationCertificateFR->d1_vehicle_brand . ' ' . $registrationCertificateFR->d3_vehicle_model) . '</li>';
+            $body .= '<li>' . $langs->transnoentities('Date') . ' : ' . dol_print_date(dol_now(), 'dayhour') . '</li>';
+            $body .= '<li>' . $langs->transnoentities('Comment') . ' : ' . dol_escape_htmltag($comment) . '</li>';
+            $body .= '</ul>';
+            $body .= '<p><a href="' . $vehicleLink . '">' . $langs->transnoentities('AccessVehicleSheet') . '</a></p>';
+
+            $mailFile = new CMailFile($subject, $sendTo, $from, $body, $attachmentPaths, $attachmentMimes, $attachmentNames, '', '', 0, 1);
+            $mailFile->sendfile();
+        }
+
+        // Clean the temp token + dir
+        saturne_invalidate_upload_token($problemUploadContext, 'dolicar', 'problem_report');
+
+        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $id . '&entity=' . $entity . '&success=1&problem=1');
+        exit;
+    }
+
     if ($action == 'get_registration_number') {
         $registrationNumber = GETPOST('registration_number');
         header('Location: ' . $_SERVER['PHP_SELF'] . '?registration_number=' . $registrationNumber . '&entity=' . $entity);
@@ -259,7 +378,11 @@ if ($success) {
     $showScreen  = 'success';
     $successType = $isVehicleOut ? 'depart' : 'retour';
 } elseif ($id > 0 && $registrationCertificateFR->id > 0) {
-    $showScreen = in_array($actionType, ['depart', 'retour']) ? 'form' : 'vehicle';
+    if ($actionType === 'probleme') {
+        $showScreen = 'problem';
+    } else {
+        $showScreen = in_array($actionType, ['depart', 'retour']) ? 'form' : 'vehicle';
+    }
 } else {
     $showScreen = 'search';
 }
@@ -420,6 +543,12 @@ $logoUrl     = DOL_URL_ROOT . '/custom/dolicar/img/dolicar_color.svg'; ?>
                 <div class="plv2-action-btn__icon"><i class="fas fa-sign-in-alt"></i></div>
                 <div class="plv2-action-btn__label"><?php echo $langs->trans('ReturnVehicle'); ?></div>
                 <div class="plv2-action-btn__sub"><?php echo $langs->trans('DeclareReturn'); ?></div>
+            </a>
+            <a href="<?php echo $vehicleUrl . '&action_type=probleme'; ?>"
+               class="plv2-action-btn plv2-action-btn--probleme">
+                <div class="plv2-action-btn__icon"><i class="fas fa-exclamation-triangle"></i></div>
+                <div class="plv2-action-btn__label"><?php echo $langs->trans('ReportProblem'); ?></div>
+                <div class="plv2-action-btn__sub"><?php echo $langs->trans('ReportProblemSub'); ?></div>
             </a>
         </div>
 
@@ -649,37 +778,95 @@ $logoUrl     = DOL_URL_ROOT . '/custom/dolicar/img/dolicar_color.svg'; ?>
         </div>
     </form>
 
+<?php elseif ($showScreen === 'problem') : ?>
+    <!-- ===== SCREEN : signaler un problème ===== -->
+    <div class="plv2-header plv2-header--dark">
+        <div class="plv2-header__top">
+            <a href="<?php echo $vehicleUrl; ?>" class="plv2-back-btn"><i class="fas fa-arrow-left"></i></a>
+            <div class="plv2-header__logo">
+                <img src="<?php echo $logoUrl; ?>" alt="DoliCar" class="plv2-header__logo-img">
+                <div class="plv2-header__logo-text">
+                    <span class="plv2-action-badge plv2-action-badge--probleme"><?php echo $langs->trans('ReportProblem'); ?></span>
+                    <small><?php echo dol_escape_htmltag($registrationCertificateFR->a_registration_number . ' · ' . $registrationCertificateFR->d1_vehicle_brand . ' ' . $registrationCertificateFR->d3_vehicle_model); ?></small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <form id="public-vehicle-problem-form" method="POST" action="<?php echo $vehicleUrl; ?>">
+        <input type="hidden" name="token" value="<?php echo newToken(); ?>">
+        <input type="hidden" name="action" value="report_problem">
+
+        <div class="plv2-form">
+            <div class="plv2-card">
+                <div class="plv2-form-group">
+                    <label for="problem_comment"><?php echo $langs->trans('Comment'); ?></label>
+                    <textarea id="problem_comment" name="problem_comment" rows="4" placeholder="<?php echo dol_escape_htmltag($langs->trans('DescribeProblem')); ?>"></textarea>
+                </div>
+                <div class="plv2-form-group">
+                    <label><?php echo $langs->trans('PhotoAndVoiceMemo'); ?></label>
+                    <div class="dolicar-problem-media-row">
+                        <?php print saturne_render_media_block('dolicar', $problemUploadSubDir, 'problem_', '', ['show_photo' => true, 'show_audio' => true, 'show_file' => false]); ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="plv2-submit-area">
+            <button type="submit" class="plv2-btn plv2-btn--full plv2-btn--primary">
+                <i class="fas fa-paper-plane"></i>
+                <?php echo $langs->trans('SendReport'); ?>
+            </button>
+        </div>
+    </form>
+
 <?php elseif ($showScreen === 'success') : ?>
     <!-- ===== SCREEN 4 : confirmation ===== -->
     <?php
+    $problemSuccess  = GETPOSTINT('problem');
     $successIsDepart = $isVehicleOut;
     $successAction   = $successIsDepart ? ($lastUnfinishedActionComm[0] ?? null) : ($lastActionComm[0] ?? null);
     ?>
     <div class="plv2-success">
-        <div class="plv2-success__icon <?php echo $successIsDepart ? 'plv2-success__icon--blue' : 'plv2-success__icon--green'; ?>">
-            <i class="fas fa-check"></i>
-        </div>
-        <h2><?php echo $successIsDepart ? $langs->trans('DepartureRecorded') : $langs->trans('ReturnRecorded'); ?></h2>
-        <p><?php echo $langs->trans('ActionCommCreatedInAgenda'); ?></p>
+        <?php if ($problemSuccess) : ?>
+            <div class="plv2-success__icon plv2-success__icon--green">
+                <i class="fas fa-check"></i>
+            </div>
+            <h2><?php echo $langs->trans('ProblemReportSent'); ?></h2>
+            <p><?php echo $langs->trans('ProblemReportSentDesc'); ?></p>
 
-        <div class="plv2-success__recap">
-            <div class="plv2-success__row">
-                <span><?php echo $langs->trans('Vehicle'); ?></span>
-                <span><?php echo dol_escape_htmltag($registrationCertificateFR->d1_vehicle_brand . ' ' . $registrationCertificateFR->d3_vehicle_model . ' (' . $registrationCertificateFR->a_registration_number . ')'); ?></span>
-            </div>
-            <div class="plv2-success__row">
-                <span><?php echo $langs->trans('Type'); ?></span>
-                <span class="<?php echo $successIsDepart ? 'plv2-text--blue' : 'plv2-text--green'; ?>">
-                    <?php echo $successIsDepart ? $langs->trans('Departure') : $langs->trans('Return'); ?>
-                </span>
-            </div>
-            <?php if (!empty($successAction)) : ?>
+            <div class="plv2-success__recap">
                 <div class="plv2-success__row">
-                    <span><?php echo $langs->trans('Date'); ?></span>
-                    <span><?php echo dol_print_date($successIsDepart ? $successAction->datep : $successAction->datef, 'dayhour'); ?></span>
+                    <span><?php echo $langs->trans('Vehicle'); ?></span>
+                    <span><?php echo dol_escape_htmltag($registrationCertificateFR->d1_vehicle_brand . ' ' . $registrationCertificateFR->d3_vehicle_model . ' (' . $registrationCertificateFR->a_registration_number . ')'); ?></span>
                 </div>
-            <?php endif; ?>
-        </div>
+            </div>
+        <?php else : ?>
+            <div class="plv2-success__icon <?php echo $successIsDepart ? 'plv2-success__icon--blue' : 'plv2-success__icon--green'; ?>">
+                <i class="fas fa-check"></i>
+            </div>
+            <h2><?php echo $successIsDepart ? $langs->trans('DepartureRecorded') : $langs->trans('ReturnRecorded'); ?></h2>
+            <p><?php echo $langs->trans('ActionCommCreatedInAgenda'); ?></p>
+
+            <div class="plv2-success__recap">
+                <div class="plv2-success__row">
+                    <span><?php echo $langs->trans('Vehicle'); ?></span>
+                    <span><?php echo dol_escape_htmltag($registrationCertificateFR->d1_vehicle_brand . ' ' . $registrationCertificateFR->d3_vehicle_model . ' (' . $registrationCertificateFR->a_registration_number . ')'); ?></span>
+                </div>
+                <div class="plv2-success__row">
+                    <span><?php echo $langs->trans('Type'); ?></span>
+                    <span class="<?php echo $successIsDepart ? 'plv2-text--blue' : 'plv2-text--green'; ?>">
+                        <?php echo $successIsDepart ? $langs->trans('Departure') : $langs->trans('Return'); ?>
+                    </span>
+                </div>
+                <?php if (!empty($successAction)) : ?>
+                    <div class="plv2-success__row">
+                        <span><?php echo $langs->trans('Date'); ?></span>
+                        <span><?php echo dol_print_date($successIsDepart ? $successAction->datep : $successAction->datef, 'dayhour'); ?></span>
+                    </div>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
 
         <div class="plv2-success__actions">
             <a href="<?php echo $vehicleUrl; ?>" class="plv2-btn plv2-btn--primary plv2-btn--full">

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -229,7 +229,7 @@ if (empty($resHook)) {
         $problemAction->percentage   = -1;
         $problemAction->userownerid  = 0;
         $problemAction->label        = $langs->transnoentities('ProblemReportedOnVehicle', $registrationCertificateFR->a_registration_number);
-        $problemAction->note_private = (!empty($_SERVER['REMOTE_ADDR']) ? $langs->transnoentities('IPAddress') . ' : ' . $_SERVER['REMOTE_ADDR'] . '<br>' : '');
+        $problemAction->note_private = (!empty($_SERVER['REMOTE_ADDR']) ? $langs->transnoentities('IPAddress') . ' : ' . $_SERVER['REMOTE_ADDR'] . "\n" : '');
         $problemAction->note_private .= $langs->transnoentities('Comment') . ' : ' . $comment;
         $problemActionID              = $problemAction->create($user);
 

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -229,8 +229,7 @@ if (empty($resHook)) {
         $problemAction->percentage   = -1;
         $problemAction->userownerid  = 0;
         $problemAction->label        = $langs->transnoentities('ProblemReportedOnVehicle', $registrationCertificateFR->a_registration_number);
-        $problemAction->note_private = (!empty($_SERVER['REMOTE_ADDR']) ? $langs->transnoentities('IPAddress') . ' : ' . $_SERVER['REMOTE_ADDR'] . "\n" : '');
-        $problemAction->note_private .= $langs->transnoentities('Comment') . ' : ' . $comment;
+        $problemAction->note_private = $comment;
         $problemActionID              = $problemAction->create($user);
 
         // Move the uploaded media from the temp dir to a permanent location keyed by the event

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -120,6 +120,7 @@ $iconMap = [
     'Accident'           => 'fa-exclamation-triangle',
     'Autre'              => 'fa-circle',
 ];
+$iconMap[$langs->transnoentities('ReportedProblem')] = 'fa-exclamation-triangle';
 
 // Load child categories and build display structures for the TPL
 $catById   = [];
@@ -153,16 +154,23 @@ if (!empty($object->fk_lot) && $object->fk_lot > 0 && !empty($catById)) {
 
     if (is_array($allEvents)) {
         foreach ($allEvents as $evt) {
+            $matched   = false;
             $evtCatIds = $catHelper->containing($evt->id, Categorie::TYPE_ACTIONCOMM, 'id');
-            if (!is_array($evtCatIds)) {
-                continue;
-            }
-            foreach ($evtCatIds as $evtCatId) {
-                if (isset($catById[(int) $evtCatId])) {
-                    $eventsList[]               = $evt;
-                    $evtCatById[(int) $evt->id] = $catById[(int) $evtCatId];
-                    break;
+            if (is_array($evtCatIds)) {
+                foreach ($evtCatIds as $evtCatId) {
+                    if (isset($catById[(int) $evtCatId])) {
+                        $eventsList[]               = $evt;
+                        $evtCatById[(int) $evt->id] = $catById[(int) $evtCatId];
+                        $matched                    = true;
+                        break;
+                    }
                 }
+            }
+
+            // Problem reports from the public logbook carry no DoliCar category — surface them with a dedicated badge
+            if (!$matched && !empty($evt->code) && strpos($evt->code, '_REPORT_PROBLEM') !== false) {
+                $eventsList[]               = $evt;
+                $evtCatById[(int) $evt->id] = (object) ['label' => $langs->transnoentities('ReportedProblem'), 'color' => 'F59E0B'];
             }
         }
     }


### PR DESCRIPTION
## Changements
Implémente #443 : signalement d'un problème depuis le carnet de bord public du véhicule.

### Carnet de bord public ([public_vehicle_logbook.php](htdocs/custom/dolicar/public/agenda/public_vehicle_logbook.php))
- Nouvelle carte **« Signaler un problème »** (écran 2, à côté de Je prends / Je rends).
- Nouvel écran formulaire : **commentaire** + **photo** + **mémo vocal**, via la lib média Saturne `saturne_render_media_block()` (photo + audio sur la même ligne). Le commentaire utilise un textarea blanc.
- Upload géré par la page (handlers `uploadPhoto` / `add_audio`) dans un dossier temporaire scopé par un **token d'upload** de session.
- À la soumission (`report_problem`) :
  - création d'un événement agenda (`ActionComm`, code `AC_PRODUCTLOT_REPORT_PROBLEM`) sur le véhicule (visible dans l'historique) ;
  - déplacement des médias vers un dossier permanent ;
  - **email au responsable** avec plaque, commentaire, date, **lien vers la fiche véhicule** et la/les **photo(s) en pièce jointe** ;
  - nettoyage du token/dossier temporaire ;
  - écran de confirmation dédié.

### Configuration ([setup.php](htdocs/custom/dolicar/admin/setup.php))
- Nouvelle section **« Signalement de problème »** : email du responsable (`DOLICAR_PROBLEM_REPORT_EMAIL`). Si vide, l'email de la société est utilisé.

## Fichiers modifiés
- public/agenda/public_vehicle_logbook.php
- admin/setup.php
- css/scss/pages/_vehicle-logbook.scss
- langs/fr_FR/dolicar.lang

## Note build
`css/dolicar.min.css` n'est pas commité manuellement : il sera recompilé par la CI au merge.

## Tests
- Rendu de l'écran de signalement vérifié (HTTP 200, sans erreur PHP). L'upload caméra/micro et l'envoi d'email nécessitent un navigateur réel + un SMTP configuré (test côté utilisateur).

## Issue
#443
