### PR TITLE
#452 [VehicleEvent] add: link specific expense report lines to a vehicle event

### DIFF
--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -237,8 +237,7 @@ if (!empty($eventsList)) {
                 }
                 $parentEr = new ExpenseReport($db);
                 $parentEr->fetch($erLine->fk_expensereport);
-                $rawTypeLabel = $erLine->type_fees_libelle ?: ($erLine->type_fees_code ?: '');
-                $typeLabel    = $rawTypeLabel !== '' ? $langs->trans($rawTypeLabel) : '';
+                $typeLabel    = ($langs->trans($erLine->type_fees_code) != $erLine->type_fees_code) ? $langs->trans($erLine->type_fees_code) : ($erLine->type_fees_libelle ?: '');
                 $projectLabel = $erLine->projet_title ?: $erLine->projet_ref;
 
                 $linkedHtml .= '<div class="inline-block">';

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -249,21 +249,26 @@ if (!empty($eventsList)) {
                 $typeLabel    = ($langs->transnoentities($erLine->type_fees_code) != $erLine->type_fees_code) ? $langs->transnoentities($erLine->type_fees_code) : ($erLine->type_fees_libelle ?: '');
                 $projectLabel = $erLine->projet_title ?: $erLine->projet_ref;
 
-                $linkedHtml .= '<div class="inline-block">';
-                if ($parentEr->id > 0) {
-                    $linkedHtml .= $parentEr->getNomUrl(1) . ' &mdash; ';
-                }
-                $linkedHtml .= dol_print_date($erLine->date, 'day');
+                $lineParts = [];
                 if (!empty($typeLabel)) {
-                    $linkedHtml .= ' &middot; ' . dol_escape_htmltag($typeLabel);
+                    $lineParts[] = dol_escape_htmltag($typeLabel);
                 }
                 if (!empty($projectLabel)) {
-                    $linkedHtml .= ' &middot; ' . dol_escape_htmltag($projectLabel);
+                    $lineParts[] = dol_escape_htmltag($projectLabel);
                 }
-                $linkedHtml .= ' &mdash; <strong>' . price($erLine->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($erLine->comments)) {
-                    $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($erLine->comments, 80)) . '</span>';
+                    $lineParts[] = '<span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($erLine->comments, 80)) . '</span>';
                 }
+
+                $linkedHtml .= '<div class="inline-block">';
+                if ($parentEr->id > 0) {
+                    $linkedHtml .= $parentEr->getNomUrl(1);
+                    if (!empty($lineParts)) {
+                        $linkedHtml .= ' &mdash; ';
+                    }
+                }
+                $linkedHtml .= implode(' &middot; ', $lineParts);
+                $linkedHtml .= ' &mdash; <strong>' . price($erLine->total_ttc) . ' ' . $conf->currency . '</strong>';
                 $linkedHtml .= '</div><br>';
             }
         }

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -77,7 +77,7 @@ if (!empty($permissiontoadd)) {
     $out .= '<td><textarea name="event_note" class="flat minwidth400" rows="2">' . dol_escape_htmltag(GETPOST('event_note', 'restricthtml')) . '</textarea></td>';
     $out .= '</tr>';
 
-    foreach (dolicar_get_vehicle_event_linkable_types() as $linkableType) {
+    foreach (dolicar_get_vehicle_event_linkable_types() as $typeKey => $linkableType) {
         if (!dolicar_vehicle_event_type_enabled($linkableType['const'])) {
             continue;
         }
@@ -90,6 +90,14 @@ if (!empty($permissiontoadd)) {
         $out .= '<td>' . $typePicto . $langs->transnoentities($linkableType['label']) . '</td>';
         $out .= '<td>' . $form->selectForForms($linkableType['selectarg'], $linkableType['field'], GETPOSTINT($linkableType['field']), 1, '', '', 'minwidth300') . '</td>';
         $out .= '</tr>';
+
+        // Expense report: pick specific lines instead of the whole report (issue #452)
+        if ($typeKey === 'expensereport') {
+            $out .= '<tr id="dolicar-er-lines-row" style="display:none;">';
+            $out .= '<td>' . $langs->transnoentities('ExpenseReportLines') . '</td>';
+            $out .= '<td><div id="dolicar-er-lines" class="dolicar-er-lines" data-url="' . dol_escape_htmltag($_SERVER['PHP_SELF'] . '?id=' . $object->id) . '"></div></td>';
+            $out .= '</tr>';
+        }
     }
 
     $out .= '</table>';
@@ -213,6 +221,40 @@ if (!empty($eventsList)) {
                 $linkedHtml .= ' &mdash; ' . $tmpControl->getLibVerdict(4);
                 if (!empty($tmpControl->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpControl->note_public, 80)) . '</span>';
+                }
+                $linkedHtml .= '</div><br>';
+            }
+        }
+
+        // Expense report lines selected for this event (issue #452)
+        $erLineIds = array_values($evt->linkedObjectsIds['expensereportline'] ?? []);
+        if (!empty($erLineIds)) {
+            require_once DOL_DOCUMENT_ROOT . '/expensereport/class/expensereportline.class.php';
+            foreach ($erLineIds as $erLineId) {
+                $erLine = new ExpenseReportLine($db);
+                if ($erLine->fetch($erLineId) <= 0) {
+                    continue;
+                }
+                $parentEr = new ExpenseReport($db);
+                $parentEr->fetch($erLine->fk_expensereport);
+                $rawTypeLabel = $erLine->type_fees_libelle ?: ($erLine->type_fees_code ?: '');
+                $typeLabel    = $rawTypeLabel !== '' ? $langs->trans($rawTypeLabel) : '';
+                $projectLabel = $erLine->projet_title ?: $erLine->projet_ref;
+
+                $linkedHtml .= '<div class="inline-block">';
+                if ($parentEr->id > 0) {
+                    $linkedHtml .= $parentEr->getNomUrl(1) . ' &mdash; ';
+                }
+                $linkedHtml .= dol_print_date($erLine->date, 'day');
+                if (!empty($typeLabel)) {
+                    $linkedHtml .= ' &middot; ' . dol_escape_htmltag($typeLabel);
+                }
+                if (!empty($projectLabel)) {
+                    $linkedHtml .= ' &middot; ' . dol_escape_htmltag($projectLabel);
+                }
+                $linkedHtml .= ' &mdash; <strong>' . price($erLine->total_ttc) . ' ' . $conf->currency . '</strong>';
+                if (!empty($erLine->comments)) {
+                    $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($erLine->comments, 80)) . '</span>';
                 }
                 $linkedHtml .= '</div><br>';
             }

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -237,7 +237,7 @@ if (!empty($eventsList)) {
                 }
                 $parentEr = new ExpenseReport($db);
                 $parentEr->fetch($erLine->fk_expensereport);
-                $typeLabel    = ($langs->trans($erLine->type_fees_code) != $erLine->type_fees_code) ? $langs->trans($erLine->type_fees_code) : ($erLine->type_fees_libelle ?: '');
+                $typeLabel    = ($langs->transnoentities($erLine->type_fees_code) != $erLine->type_fees_code) ? $langs->transnoentities($erLine->type_fees_code) : ($erLine->type_fees_libelle ?: '');
                 $projectLabel = $erLine->projet_title ?: $erLine->projet_ref;
 
                 $linkedHtml .= '<div class="inline-block">';

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -58,7 +58,7 @@ if (!empty($permissiontoadd)) {
     $out .= '<table class="border centpercent tableforfield">';
 
     $out .= '<tr>';
-    $out .= '<td class="titlefield fieldrequired">' . $langs->transnoentities('VehicleEventType') . '</td>';
+    $out .= '<td class="titlefield">' . $langs->transnoentities('VehicleEventType') . '</td>';
     $out .= '<td>' . Form::selectarray('event_category_id', $catLabels, GETPOSTINT('event_category_id'), 1, 0, 0, '', 0, 0, 0, '', 'minwidth200') . '</td>';
     $out .= '</tr>';
 

--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -227,7 +227,16 @@ if (!empty($eventsList)) {
         }
 
         // Expense report lines selected for this event (issue #452)
-        $erLineIds = array_values($evt->linkedObjectsIds['expensereportline'] ?? []);
+        // 'expensereportline' is not a registered element, so fetchObjectLinked() drops it — read the links directly
+        $erLineIds  = [];
+        $sqlErLines = 'SELECT fk_source FROM ' . MAIN_DB_PREFIX . "element_element WHERE fk_target = " . (int) $evt->id . " AND targettype = 'action' AND sourcetype = 'expensereportline'";
+        $resErLines = $db->query($sqlErLines);
+        if ($resErLines) {
+            while ($oErLine = $db->fetch_object($resErLines)) {
+                $erLineIds[] = (int) $oErLine->fk_source;
+            }
+            $db->free($resErLines);
+        }
         if (!empty($erLineIds)) {
             require_once DOL_DOCUMENT_ROOT . '/expensereport/class/expensereportline.class.php';
             foreach ($erLineIds as $erLineId) {

--- a/css/scss/pages/_registrationcertificatefr-card.scss
+++ b/css/scss/pages/_registrationcertificatefr-card.scss
@@ -144,3 +144,14 @@
         }
     }
 }
+
+// Vehicle event form — expense report line picker (issue #452)
+.dolicar-er-lines {
+    label.dolicar-er-line {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin: 3px 0;
+        cursor: pointer;
+    }
+}

--- a/js/modules/vehicleEvent.js
+++ b/js/modules/vehicleEvent.js
@@ -1,0 +1,107 @@
+/* Copyright (C) 2026 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    js/modules/vehicleEvent.js
+ * \ingroup dolicar
+ * \brief   JavaScript module for the vehicle event form (expense report line picker)
+ */
+
+'use strict';
+
+/**
+ * Init vehicleEvent JS
+ *
+ * @memberof DoliCar_VehicleEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @type {Object}
+ */
+window.dolicar.vehicleEvent = {};
+
+/**
+ * VehicleEvent init
+ *
+ * @memberof DoliCar_VehicleEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @return {void}
+ */
+window.dolicar.vehicleEvent.init = function() {
+  window.dolicar.vehicleEvent.event();
+};
+
+/**
+ * VehicleEvent event — bind delegated handlers
+ *
+ * @memberof DoliCar_VehicleEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @return {void}
+ */
+window.dolicar.vehicleEvent.event = function() {
+  $(document).on('change', '#event_fk_expensereport', window.dolicar.vehicleEvent.loadExpenseReportLines);
+};
+
+/**
+ * Load the lines of the selected expense report and render them as checkboxes
+ *
+ * @memberof DoliCar_VehicleEvent
+ *
+ * @since   1.5.0
+ * @version 1.5.0
+ *
+ * @return {void}
+ */
+window.dolicar.vehicleEvent.loadExpenseReportLines = function() {
+  var fkExpenseReport = $(this).val();
+  var $container      = $('#dolicar-er-lines');
+  var $row            = $('#dolicar-er-lines-row');
+
+  if (!fkExpenseReport || parseInt(fkExpenseReport, 10) <= 0) {
+    $container.empty();
+    $row.hide();
+    return;
+  }
+
+  var url = $container.data('url') + '&action=get_expensereport_lines&fk_expensereport=' + encodeURIComponent(fkExpenseReport);
+
+  $.getJSON(url, function(lines) {
+    $container.empty();
+
+    if (!lines || lines.length === 0) {
+      $row.hide();
+      return;
+    }
+
+    $.each(lines, function(index, line) {
+      var $label = $('<label class="dolicar-er-line"></label>');
+      var $checkbox = $('<input type="checkbox" name="event_expensereport_lines[]">').val(line.id);
+      var $text = $('<span></span>').text(line.label + ' — ' + line.amount);
+
+      $label.append($checkbox).append($text);
+      $container.append($label);
+    });
+
+    $row.show();
+  });
+};

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -327,6 +327,7 @@ LinkedDocuments                = Documents liés
 Invoices                       = Factures
 Proposals                      = Devis
 ExpenseReports                 = Notes de frais
+ExpenseReportLines             = Lignes de note de frais
 SuppliersOrders                = Commandes fournisseurs
 SuppliersInvoices              = Factures fournisseurs
 Controls                       = Contrôles DigiQuali

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -233,6 +233,14 @@ if ($action == 'add_vehicle_event' && !empty($permissiontoadd) && !empty($object
     $fkControl       = GETPOSTINT('event_fk_control');
     $expenseReportLineIds = array_values(array_filter(array_map('intval', (array) GETPOST('event_expensereport_lines', 'array'))));
 
+    // Event type is optional: when none is picked, fall back to the "Autre" category so the event still saves and shows in the history
+    if ($eventCategoryId <= 0 && $parentCategoryId > 0) {
+        $fallbackCat = new Categorie($db);
+        if ($fallbackCat->fetch(0, 'Autre', Categorie::TYPE_ACTIONCOMM) > 0 && (int) $fallbackCat->fk_parent === $parentCategoryId) {
+            $eventCategoryId = (int) $fallbackCat->id;
+        }
+    }
+
     $selectedCat = new Categorie($db);
     if ($eventCategoryId <= 0 || $selectedCat->fetch($eventCategoryId) <= 0 || (int) $selectedCat->fk_parent !== $parentCategoryId) {
         setEventMessages($langs->transnoentities('VehicleEventType') . ' ' . $langs->transnoentities('NotValid'), null, 'errors');

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -81,7 +81,7 @@ if ($action == 'get_expensereport_lines') {
             $expenseReport->fetch_lines();
             if (is_array($expenseReport->lines)) {
                 foreach ($expenseReport->lines as $line) {
-                    $typeLabel    = ($langs->trans($line->type_fees_code) != $line->type_fees_code) ? $langs->trans($line->type_fees_code) : ($line->type_fees_libelle ?: '');
+                    $typeLabel    = ($langs->transnoentities($line->type_fees_code) != $line->type_fees_code) ? $langs->transnoentities($line->type_fees_code) : ($line->type_fees_libelle ?: '');
                     $projectLabel = $line->projet_title ?: $line->projet_ref;
                     $label        = dol_print_date($line->date, 'day');
                     if ($typeLabel !== '') {

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -83,16 +83,17 @@ if ($action == 'get_expensereport_lines') {
                 foreach ($expenseReport->lines as $line) {
                     $typeLabel    = ($langs->transnoentities($line->type_fees_code) != $line->type_fees_code) ? $langs->transnoentities($line->type_fees_code) : ($line->type_fees_libelle ?: '');
                     $projectLabel = $line->projet_title ?: $line->projet_ref;
-                    $label        = dol_print_date($line->date, 'day');
+                    $parts        = [];
                     if ($typeLabel !== '') {
-                        $label .= ' · ' . $typeLabel;
+                        $parts[] = $typeLabel;
                     }
                     if (!empty($projectLabel)) {
-                        $label .= ' · ' . $projectLabel;
+                        $parts[] = $projectLabel;
                     }
                     if (!empty($line->comments)) {
-                        $label .= ' · ' . dol_trunc($line->comments, 40);
+                        $parts[] = dol_trunc($line->comments, 60);
                     }
+                    $label = implode(' · ', $parts);
                     $linesData[] = [
                         'id'     => (int) $line->rowid,
                         'label'  => $label,

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -81,8 +81,7 @@ if ($action == 'get_expensereport_lines') {
             $expenseReport->fetch_lines();
             if (is_array($expenseReport->lines)) {
                 foreach ($expenseReport->lines as $line) {
-                    $rawTypeLabel = $line->type_fees_libelle ?: ($line->type_fees_code ?: '');
-                    $typeLabel    = $rawTypeLabel !== '' ? $langs->trans($rawTypeLabel) : '';
+                    $typeLabel    = ($langs->trans($line->type_fees_code) != $line->type_fees_code) ? $langs->trans($line->type_fees_code) : ($line->type_fees_libelle ?: '');
                     $projectLabel = $line->projet_title ?: $line->projet_ref;
                     $label        = dol_print_date($line->date, 'day');
                     if ($typeLabel !== '') {

--- a/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
+++ b/view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php
@@ -48,7 +48,7 @@ require_once __DIR__ . '/../../class/registrationcertificatefr.class.php';
 global $conf, $db, $form, $langs, $user;
 
 // Load translation files required by the page
-saturne_load_langs();
+saturne_load_langs(['trips']);
 
 // Get parameters
 $id     = GETPOST('id', 'int');
@@ -68,6 +68,46 @@ require_once DOL_DOCUMENT_ROOT . '/core/actions_fetchobject.inc.php'; // Must be
 $permissionToRead = $user->rights->dolicar->registrationcertificatefr->read;
 $permissiontoadd  = $user->rights->dolicar->registrationcertificatefr->write;
 saturne_check_access($permissionToRead);
+
+// AJAX: return the lines of an expense report for the vehicle-event form (issue #452)
+if ($action == 'get_expensereport_lines') {
+    require_once DOL_DOCUMENT_ROOT . '/expensereport/class/expensereport.class.php';
+
+    $fkExpenseReport = GETPOSTINT('fk_expensereport');
+    $linesData       = [];
+    if ($fkExpenseReport > 0) {
+        $expenseReport = new ExpenseReport($db);
+        if ($expenseReport->fetch($fkExpenseReport) > 0) {
+            $expenseReport->fetch_lines();
+            if (is_array($expenseReport->lines)) {
+                foreach ($expenseReport->lines as $line) {
+                    $rawTypeLabel = $line->type_fees_libelle ?: ($line->type_fees_code ?: '');
+                    $typeLabel    = $rawTypeLabel !== '' ? $langs->trans($rawTypeLabel) : '';
+                    $projectLabel = $line->projet_title ?: $line->projet_ref;
+                    $label        = dol_print_date($line->date, 'day');
+                    if ($typeLabel !== '') {
+                        $label .= ' · ' . $typeLabel;
+                    }
+                    if (!empty($projectLabel)) {
+                        $label .= ' · ' . $projectLabel;
+                    }
+                    if (!empty($line->comments)) {
+                        $label .= ' · ' . dol_trunc($line->comments, 40);
+                    }
+                    $linesData[] = [
+                        'id'     => (int) $line->rowid,
+                        'label'  => $label,
+                        'amount' => price($line->total_ttc, 0, $langs, 1, -1, -1, $conf->currency),
+                    ];
+                }
+            }
+        }
+    }
+
+    header('Content-Type: application/json');
+    echo json_encode($linesData);
+    exit;
+}
 
 // Ensure parent event category exists and children are initialized
 $parentCategoryId = getDolGlobalInt('DOLICAR_VEHICLE_EVENT_CATEGORY_ID');
@@ -192,6 +232,7 @@ if ($action == 'add_vehicle_event' && !empty($permissiontoadd) && !empty($object
     $fkSupplierOrder = GETPOSTINT('event_fk_supplierorder');
     $fkSupplierInvoice = GETPOSTINT('event_fk_supplierinvoice');
     $fkControl       = GETPOSTINT('event_fk_control');
+    $expenseReportLineIds = array_values(array_filter(array_map('intval', (array) GETPOST('event_expensereport_lines', 'array'))));
 
     $selectedCat = new Categorie($db);
     if ($eventCategoryId <= 0 || $selectedCat->fetch($eventCategoryId) <= 0 || (int) $selectedCat->fk_parent !== $parentCategoryId) {
@@ -226,8 +267,13 @@ if ($action == 'add_vehicle_event' && !empty($permissiontoadd) && !empty($object
             if ($fkPropal > 0) {
                 $actionComm->add_object_linked('propal', $fkPropal);
             }
-            if ($fkExpenseReport > 0) {
+            // Link the whole expense report only when no specific lines were selected (issue #452)
+            if (empty($expenseReportLineIds) && $fkExpenseReport > 0) {
                 $actionComm->add_object_linked('expensereport', $fkExpenseReport);
+            }
+            // Otherwise link the selected expense report lines (core element_element table, no schema change)
+            foreach ($expenseReportLineIds as $expenseReportLineId) {
+                $actionComm->add_object_linked('expensereportline', $expenseReportLineId);
             }
             if ($fkSupplierOrder > 0) {
                 $actionComm->add_object_linked('order_supplier', $fkSupplierOrder);


### PR DESCRIPTION
## Changements
Implémente #452 : dans un événement véhicule (onglet Historique), pouvoir rattacher **des lignes précises d'une note de frais** plutôt que la note entière.

### Formulaire d'événement
- Sélection d'une note de frais → ses **lignes apparaissent en cases à cocher** (date · type · projet · commentaire · montant TTC), chargées en **AJAX** (cascade).
- On coche les lignes à rattacher.

### Stockage (prod-safe, aucune modif de schéma)
- Les lignes sélectionnées sont liées via la table core `llx_element_element` (`add_object_linked('expensereportline', …)`), comme le sont déjà les factures/devis/contrôles. **Aucun extrafield / aucune colonne ajoutée.**
- Si des lignes sont cochées, on ne lie pas la note de frais entière (et inversement, rétro-compatible).

### Affichage historique
- Pour chaque ligne rattachée : lien vers la note de frais parente + date · type · **projet** · montant TTC · **commentaire**.
- Le type de frais est traduit (lang `trips`).

## Fichiers modifiés
- view/registrationcertificatefr/registrationcertificatefr_vehiclehistory.php (AJAX lignes + sauvegarde)
- core/tpl/registrationcertificatefr_vehicle_history.tpl.php (formulaire + affichage)
- js/modules/vehicleEvent.js (nouveau — cascade)
- css/scss/pages/_registrationcertificatefr-card.scss (mise en page des cases)
- langs/fr_FR/dolicar.lang

## Note build
`js/dolicar.min.js` / `css/dolicar.min.css` non commités : recompilés par la CI au merge.

## Issue
#452
