### PR TITLE
#446 [PublicVehicleLogBook] add: photo and voice comments on vehicle pickup/return

### DIFF
--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -35,7 +35,7 @@
     .plv2-header {
       background: linear-gradient(135deg, #1d2937, #0f1822);
       color: #fff;
-      padding: 14px 20px 16px;
+      padding: 10px 16px;
       position: sticky;
       top: 0;
       z-index: 5;
@@ -122,24 +122,24 @@
     }
 
     .plv2-form {
-      padding: 16px;
-      padding-bottom: 80px; // room for sticky submit
+      padding: 10px;
+      padding-bottom: 70px; // room for sticky submit
     }
 
     // ── Card ─────────────────────────────────────────────────────────────
     .plv2-card {
       background: #fff;
-      border-radius: 14px;
-      padding: 16px;
+      border-radius: 12px;
+      padding: 10px 12px;
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-      margin-bottom: 14px;
+      margin-bottom: 8px;
 
       h3 {
         font-size: 13px;
         color: #1d2937;
         font-weight: 600;
-        margin: 0 0 14px;
-        padding-bottom: 10px;
+        margin: 0 0 8px;
+        padding-bottom: 6px;
         border-bottom: 1px solid #eef0f3;
         display: flex;
         align-items: center;
@@ -477,7 +477,7 @@
 
     // ── Form elements ─────────────────────────────────────────────────────
     .plv2-form-group {
-      margin-bottom: 14px;
+      margin-bottom: 8px;
 
       &:last-child { margin-bottom: 0; }
 
@@ -488,7 +488,7 @@
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.3px;
-        margin-bottom: 6px;
+        margin-bottom: 3px;
       }
 
       input[type="text"],
@@ -497,7 +497,7 @@
       select,
       textarea {
         width: 100%;
-        padding: 12px 14px;
+        padding: 8px 10px;
         border: 1px solid #d4d8de;
         border-radius: 10px;
         font-size: 15px;
@@ -671,7 +671,7 @@
       border: 2px dashed #d4d8de;
       border-radius: 10px;
       background: #fafbfc;
-      min-height: 130px;
+      min-height: 90px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -595,6 +595,7 @@
       background: #fff;
       border: 1px solid #d4d8de;
       border-radius: 8px;
+      margin: 0; // kill pico.css default button margin-bottom (extra space under the fuel row)
       padding: 5px 3px;
       cursor: pointer;
       font-family: inherit;
@@ -668,7 +669,7 @@
       border: 2px dashed #d4d8de;
       border-radius: 10px;
       background: #fafbfc;
-      min-height: 55px;
+      min-height: 120px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -28,7 +28,7 @@
     max-width: 480px;
     margin: 0 auto;
     font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
-    font-size: 14px;
+    font-size: 12.5px;
     color: #1d2937;
 
     // ── Header ──────────────────────────────────────────────────────────
@@ -122,28 +122,28 @@
     }
 
     .plv2-form {
-      padding: 10px;
-      padding-bottom: 70px; // room for sticky submit
+      padding: 6px;
+      padding-bottom: 64px; // room for sticky submit
     }
 
     // ── Card ─────────────────────────────────────────────────────────────
     .plv2-card {
       background: #fff;
-      border-radius: 12px;
-      padding: 10px 12px;
+      border-radius: 10px;
+      padding: 7px 9px;
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-      margin-bottom: 8px;
+      margin-bottom: 5px;
 
       h3 {
-        font-size: 13px;
+        font-size: 12px;
         color: #1d2937;
         font-weight: 600;
-        margin: 0 0 8px;
-        padding-bottom: 6px;
+        margin: 0 0 5px;
+        padding-bottom: 4px;
         border-bottom: 1px solid #eef0f3;
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 6px;
 
         i { color: #1571d3; }
       }
@@ -477,18 +477,18 @@
 
     // ── Form elements ─────────────────────────────────────────────────────
     .plv2-form-group {
-      margin-bottom: 8px;
+      margin-bottom: 4px;
 
       &:last-child { margin-bottom: 0; }
 
       label {
         display: block;
-        font-size: 11px;
+        font-size: 10px;
         color: #5b6470;
         font-weight: 600;
         text-transform: uppercase;
         letter-spacing: 0.3px;
-        margin-bottom: 3px;
+        margin-bottom: 2px;
       }
 
       input[type="text"],
@@ -497,10 +497,10 @@
       select,
       textarea {
         width: 100%;
-        padding: 8px 10px;
+        padding: 6px 9px;
         border: 1px solid #d4d8de;
-        border-radius: 10px;
-        font-size: 15px;
+        border-radius: 8px;
+        font-size: 13px;
         font-family: inherit;
         background: #fff;
         color: #1d2937;
@@ -546,17 +546,17 @@
 
       .saturne-media-btn,
       .saturne-upload-label {
-        width: 48px;
-        min-width: 48px;
-        height: 48px;
+        width: 38px;
+        min-width: 38px;
+        height: 38px;
         margin: 0;
         padding: 0;
         display: inline-flex;
         align-items: center;
         justify-content: center;
-        border-radius: 10px;
+        border-radius: 8px;
 
-        i { font-size: 18px; }
+        i { font-size: 15px; }
       }
     }
 
@@ -573,7 +573,7 @@
     .plv2-km-input {
       font-family: "Courier New", monospace !important;
       font-weight: 700 !important;
-      font-size: 22px !important;
+      font-size: 15px !important;
       text-align: center;
       letter-spacing: 1px;
     }
@@ -598,7 +598,7 @@
       background: #fff;
       border: 1px solid #d4d8de;
       border-radius: 8px;
-      padding: 10px 4px;
+      padding: 5px 3px;
       cursor: pointer;
       font-family: inherit;
       font-size: 10px;
@@ -607,9 +607,9 @@
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 4px;
+      gap: 2px;
 
-      i { font-size: 18px; }
+      i { font-size: 14px; }
 
       &:hover { border-color: #93c5fd; }
 
@@ -671,7 +671,7 @@
       border: 2px dashed #d4d8de;
       border-radius: 10px;
       background: #fafbfc;
-      min-height: 90px;
+      min-height: 55px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -481,14 +481,9 @@
 
       &:last-child { margin-bottom: 0; }
 
+      // Field labels hidden — only the global card titles (h3) are kept
       label {
-        display: block;
-        font-size: 10px;
-        color: #5b6470;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.3px;
-        margin-bottom: 2px;
+        display: none;
       }
 
       input[type="text"],

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -492,10 +492,12 @@
       select,
       textarea {
         width: 100%;
-        padding: 6px 9px;
+        padding: 5px 8px;
+        margin: 0; // kill pico.css default input margin-bottom (extra space under each field)
         border: 1px solid #d4d8de;
         border-radius: 8px;
         font-size: 13px;
+        line-height: 1.3;
         font-family: inherit;
         background: #fff;
         color: #1d2937;
@@ -567,10 +569,10 @@
 
     .plv2-km-input {
       font-family: "Courier New", monospace !important;
-      font-weight: 700 !important;
-      font-size: 15px !important;
+      font-weight: 600 !important;
+      font-size: 13px !important;
       text-align: center;
-      letter-spacing: 1px;
+      letter-spacing: 0.5px;
     }
 
     .plv2-km-hint {

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -516,7 +516,8 @@
       textarea { resize: vertical; }
     }
 
-    .dolicar-problem-media-row {
+    .dolicar-problem-media-row,
+    .dolicar-trip-media-row {
       display: flex;
       align-items: center;
       gap: 14px;
@@ -796,6 +797,16 @@
         justify-content: space-between;
         align-items: center;
         margin-bottom: 8px;
+      }
+
+      &__media {
+        display: flex;
+        gap: 14px;
+        margin-top: 8px;
+        font-size: 12px;
+        color: #5b6470;
+
+        i { margin-right: 3px; }
       }
 
       &__driver {

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -156,6 +156,10 @@ require_once __DIR__ . '/../../../saturne/lib/medias.lib.php';
 $problemUploadContext = 'dolicar_problem_report_' . $id;
 $problemUploadSubDir  = 'problem_report/' . saturne_get_upload_token($problemUploadContext);
 
+// Trip photo/voice comments (issue #446): per-session temp dir keyed by an upload token
+$tripUploadContext = 'dolicar_vehicle_trip_' . $id;
+$tripUploadSubDir  = 'vehicle_trip/' . saturne_get_upload_token($tripUploadContext);
+
 /*
  * Actions
  */
@@ -353,6 +357,22 @@ if (empty($resHook)) {
             $signatory->signature_url = generate_random_id(); // Mandatory: column has a UNIQUE index, must not stay empty
 
             $signatory->create($user);
+        }
+
+        // Attach the uploaded photo/voice comments to the trip event (issue #446)
+        $tripActionId = $actionCommID ?? (isset($lastUnfinishedActionComm[0]) ? $lastUnfinishedActionComm[0]->id : 0);
+        if ($tripActionId > 0) {
+            $tripMediaFiles = saturne_get_media_files('dolicar', $tripUploadSubDir);
+            if (!empty($tripMediaFiles)) {
+                $tripFinalDir = $conf->dolicar->dir_output . '/vehicle_trip/' . (int) $tripActionId;
+                if (!dol_is_dir($tripFinalDir)) {
+                    dol_mkdir($tripFinalDir);
+                }
+                foreach ($tripMediaFiles as $tripMediaFile) {
+                    dol_move($tripMediaFile['fullname'], $tripFinalDir . '/' . $tripMediaFile['name'], 0, 1, 0, 0);
+                }
+            }
+            saturne_invalidate_upload_token($tripUploadContext, 'dolicar', 'vehicle_trip');
         }
 
         header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $id . '&entity=' . $entity . '&success=1');
@@ -622,6 +642,30 @@ $logoUrl     = DOL_URL_ROOT . '/custom/dolicar/img/dolicar_color.svg'; ?>
                                 </div>
                             <?php endif; ?>
                         <?php endif; ?>
+                        <?php
+                        $acMediaDir   = $conf->dolicar->dir_output . '/vehicle_trip/' . (int) $ac->id;
+                        $acPhotoCount = 0;
+                        $acAudioCount = 0;
+                        if (dol_is_dir($acMediaDir)) {
+                            foreach (dol_dir_list($acMediaDir, 'files', 0, '', '(\.meta|_preview.*\.png)$') as $acMediaFile) {
+                                if (image_format_supported($acMediaFile['name']) >= 0) {
+                                    $acPhotoCount++;
+                                } elseif (preg_match('/\.(wav|mp3|ogg|m4a)$/i', $acMediaFile['name'])) {
+                                    $acAudioCount++;
+                                }
+                            }
+                        }
+                        ?>
+                        <?php if ($acPhotoCount > 0 || $acAudioCount > 0) : ?>
+                            <div class="plv2-history-item__media">
+                                <?php if ($acPhotoCount > 0) : ?>
+                                    <span><i class="fas fa-camera"></i> <?php echo $acPhotoCount; ?></span>
+                                <?php endif; ?>
+                                <?php if ($acAudioCount > 0) : ?>
+                                    <span><i class="fas fa-microphone"></i> <?php echo $acAudioCount; ?></span>
+                                <?php endif; ?>
+                            </div>
+                        <?php endif; ?>
                     </div>
                 <?php endforeach; ?>
             </div>
@@ -749,6 +793,12 @@ $logoUrl     = DOL_URL_ROOT . '/custom/dolicar/img/dolicar_color.svg'; ?>
                     <textarea name="<?php echo $isDepart ? 'start_comment' : 'end_comment'; ?>"
                               rows="3"
                               placeholder="<?php echo $langs->trans('RemarksPlaceholder'); ?>"></textarea>
+                </div>
+                <div class="plv2-form-group">
+                    <label><?php echo $langs->trans('PhotoAndVoiceMemo'); ?></label>
+                    <div class="dolicar-trip-media-row">
+                        <?php print saturne_render_media_block('dolicar', $tripUploadSubDir, 'trip_', '', ['show_photo' => true, 'show_audio' => true, 'show_file' => false]); ?>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Changements
Implémente #446 : ajout de commentaires **photo** et **vocal** sur l'interface publique de prise/retour de véhicule (carnet de bord public).

### Formulaire « Je prends / Je rends »
- Dans la carte « Observation », ajout d'un bloc média Saturne (`saturne_render_media_block`) : **photo** + **mémo vocal**, sur la même ligne, sous le commentaire texte.
- Upload géré par les handlers existants (`uploadPhoto` / `add_audio`) dans un dossier temporaire scopé par un token d'upload de session (réutilise l'infra de #443).

### Stockage (prod-safe, aucune modif de schéma)
- À la validation, les médias sont déplacés du dossier temporaire vers `dolicar/vehicle_trip/{id_evenement}/` (départ et retour alimentent le même dossier du trajet), puis le token est invalidé.

### Affichage
- Dans la liste des derniers trajets, un indicateur affiche le nombre de photos / mémos vocaux attachés à chaque trajet (sans exposer les fichiers via `document.php` en anonyme).

## Fichiers modifiés
- public/agenda/public_vehicle_logbook.php
- css/scss/pages/_vehicle-logbook.scss

## Note build
`css/dolicar.min.css` non commité : recompilé par la CI au merge.

## Reste à préciser
- Le 2e point de l'issue (« commentaires sur les révisions lien avec un vocal ») est ambigu — à cadrer. La partie « commentaires vocaux/photo sur la prise de véhicule » est couverte.

## Issue
#446
