### PR TITLE
#459 [PublicControl] feat: icon + short label for vehicle logbook tab

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -431,7 +431,8 @@ class ActionsDoliCar
                         $langs->load('dolicar@dolicar');
 
                         print '<a class="tab" href="' . dol_buildpath('custom/dolicar/public/agenda/public_vehicle_logbook.php?id=' . $parameters['objectId'] . '&entity=' . $parameters['entity'], 1) . '">';
-                        print $langs->transnoentities('PublicVehicleLogBook');
+                        print '<i class="fas fa-car"></i>';
+                        print '<span>' . $langs->transnoentities('PublicVehicleLogBookShort') . '</span>';
                         print '</a>';
                     }
                 }

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -217,6 +217,7 @@ LinkDolicar_registrationcertificatefrDescription = Permet la liaison entre les c
 
 # Public interface - Interface publique
 PublicVehicleLogBook          = Carnet de bord publique du véhicule
+PublicVehicleLogBookShort     = Carnet de bord
 Driver                        = Conducteur
 DriverName                    = Nom du conducteur
 StartDateAndHour              = Date et heure de départ


### PR DESCRIPTION
## Changements

Adapte l'onglet « Carnet de bord » injecté par dolicar dans la barre de navigation PWA de la page publique d'historique de contrôle DigiQuali (hook `digiqualiPublicControlTab`) :

- ajout d'une icône `fas fa-car` ;
- libellé court « Carnet de bord » (nouvelle clé `PublicVehicleLogBookShort`) au lieu de « Carnet de bord publique du véhicule », trop long pour la barre ;
- structure `<i>` + `<span>` conforme au markup des autres onglets (icône au-dessus, libellé dessous).

Va de pair avec la PWA de la page publique DigiQuali : Evarisk/digiquali#2453.

## Fichiers modifiés

- `class/actions_dolicar.class.php`
- `langs/fr_FR/dolicar.lang`

## Issue

Fixes #459
