### PR TITLE
#457 [VehicleLogBook] feat: before/after vehicle PDF sheets + public trips screen with per-trip download

### DIFF
--- a/core/modules/dolicar/dolicardocuments/dolicar_pdf_document.php
+++ b/core/modules/dolicar/dolicardocuments/dolicar_pdf_document.php
@@ -481,5 +481,296 @@ if (!class_exists('DolicarPdfRender')) {
             $this->mc($w, $h, '  ' . $box2Label, 'L', $this->margeGauche + $w + $gap, $y, 1, true, 'T');
             $this->pdf->SetXY($this->margeGauche, $y + $h);
         }
+
+        /**
+         * Draw a "before / after" comparison block: a header (field | left | right) then one row
+         * per field. A row is either textual (['label', 'left', 'right']) or an image row
+         * (['label', 'leftImg', 'rightImg', 'image' => true]) used for the départ/retour signatures.
+         *
+         * @param  string $leftHeader  Header of the left (departure) column
+         * @param  string $rightHeader Header of the right (return) column
+         * @param  array  $rows        List of rows (text or image)
+         * @return void
+         */
+        public function beforeAfterGrid(string $leftHeader, string $rightHeader, array $rows): void
+        {
+            $labelW = 32;
+            $colW   = ($this->usableW - $labelW) / 2;
+
+            // Header band: empty corner + the two column titles
+            $h = 7;
+            $this->checkPageBreak($h + 8);
+            $y = $this->pdf->GetY();
+            $this->pdf->SetFont('', 'B', 8.5);
+            $this->pdf->SetTextColor(...$this->white);
+            $this->pdf->SetFillColor(...$this->navy);
+            $this->pdf->SetDrawColor(...$this->navy);
+            $this->mc($labelW, $h, '', 'L', $this->margeGauche, $y);
+            $this->mc($colW, $h, $leftHeader, 'C', $this->margeGauche + $labelW, $y);
+            $this->mc($colW, $h, $rightHeader, 'C', $this->margeGauche + $labelW + $colW, $y);
+            $this->pdf->SetXY($this->margeGauche, $y + $h);
+
+            foreach ($rows as $row) {
+                $isImage = !empty($row['image']);
+                if ($isImage) {
+                    $rowH = 24;
+                } else {
+                    $this->pdf->SetFont('', '', 9);
+                    $rowH = $this->rowHeight([
+                        [$colW, (string) ($row['left'] ?? '')],
+                        [$colW, (string) ($row['right'] ?? '')],
+                    ], 6);
+                }
+
+                $this->checkPageBreak($rowH);
+                $y = $this->pdf->GetY();
+
+                // Label cell (navy text on light background)
+                $this->pdf->SetFont('', 'B', 9);
+                $this->pdf->SetTextColor(...$this->navy);
+                $this->pdf->SetFillColor(...$this->light);
+                $this->pdf->SetDrawColor(...$this->border);
+                $this->mc($labelW, $rowH, (string) ($row['label'] ?? ''), 'L', $this->margeGauche, $y);
+
+                if ($isImage) {
+                    $this->pdf->SetFillColor(...$this->white);
+                    $this->mc($colW, $rowH, '', 'C', $this->margeGauche + $labelW, $y);
+                    $this->mc($colW, $rowH, '', 'C', $this->margeGauche + $labelW + $colW, $y);
+                    if (!empty($row['leftImg'])) {
+                        $this->drawCellImages([$row['leftImg']], $this->margeGauche + $labelW, $y, $colW, $rowH);
+                    }
+                    if (!empty($row['rightImg'])) {
+                        $this->drawCellImages([$row['rightImg']], $this->margeGauche + $labelW + $colW, $y, $colW, $rowH);
+                    }
+                } else {
+                    $this->pdf->SetFont('', '', 9);
+                    $this->pdf->SetTextColor(...$this->black);
+                    $this->pdf->SetFillColor(...$this->white);
+                    $this->mc($colW, $rowH, (string) ($row['left'] ?? '') !== '' ? (string) $row['left'] : '—', 'L', $this->margeGauche + $labelW, $y);
+                    $this->mc($colW, $rowH, (string) ($row['right'] ?? '') !== '' ? (string) $row['right'] : '—', 'L', $this->margeGauche + $labelW + $colW, $y);
+                }
+                $this->pdf->SetXY($this->margeGauche, $y + $rowH);
+            }
+        }
+
+        /**
+         * Draw a grid of photos read from disk, each fitted (aspect ratio kept) inside a fixed cell.
+         *
+         * @param  array  $paths    List of absolute image file paths
+         * @param  string $emptyTxt Message shown when there is no photo
+         * @param  int    $perRow   Number of photos per row
+         * @param  float  $cellH    Height of each photo cell in mm
+         * @return void
+         */
+        public function photoGrid(array $paths, string $emptyTxt = '', int $perRow = 3, float $cellH = 42): void
+        {
+            $paths = array_values(array_filter($paths, static function ($p) {
+                return !empty($p) && is_file($p);
+            }));
+
+            if (empty($paths)) {
+                $this->checkPageBreak(7);
+                $y = $this->pdf->GetY();
+                $this->pdf->SetFont('', 'I', 8.5);
+                $this->pdf->SetTextColor(...$this->gray);
+                $this->pdf->SetFillColor(...$this->white);
+                $this->pdf->SetDrawColor(...$this->border);
+                $this->mc($this->usableW, 7, $emptyTxt, 'C', $this->margeGauche, $y);
+                $this->pdf->SetXY($this->margeGauche, $y + 7);
+                return;
+            }
+
+            $gap   = 3;
+            $cellW = ($this->usableW - $gap * ($perRow - 1)) / $perRow;
+            $pad   = 1.5;
+
+            for ($i = 0, $count = count($paths); $i < $count; $i += $perRow) {
+                $this->checkPageBreak($cellH + $gap);
+                $y = $this->pdf->GetY();
+                for ($c = 0; $c < $perRow; $c++) {
+                    if (!isset($paths[$i + $c])) {
+                        break;
+                    }
+                    $x = $this->margeGauche + $c * ($cellW + $gap);
+                    $this->pdf->SetFillColor(...$this->zebra);
+                    $this->pdf->SetDrawColor(...$this->border);
+                    $this->mc($cellW, $cellH, '', 'C', $x, $y);
+                    $this->pdf->Image($paths[$i + $c], $x + $pad, $y + $pad, $cellW - $pad * 2, $cellH - $pad * 2, '', '', '', false, 300, '', false, false, 0, 'CM');
+                }
+                $this->pdf->SetXY($this->margeGauche, $y + $cellH + $gap);
+            }
+        }
+    }
+}
+
+if (!class_exists('DolicarPdfData')) {
+    /**
+     * Shared data access for DoliCar vehicle logbook PDF models: fetch the trips of a vehicle
+     * with their driver info, mileages, comments, départ/retour signatures and départ/retour photos.
+     */
+    class DolicarPdfData
+    {
+        /**
+         * Fetch the public-logbook trips of a vehicle (RegistrationCertificateFr).
+         *
+         * Each returned trip is an associative array carrying everything the PDF models need:
+         * driver, mileages, comments, fuel, départ/retour signatures (raw PNG binary) and
+         * départ/retour photos (absolute file paths, with a legacy fallback for trips recorded
+         * before the départ/retour split of issue #457).
+         *
+         * @param  DoliDB $db            Database handler
+         * @param  object $object        RegistrationCertificateFr source object (needs fk_lot)
+         * @param  bool   $onlyCompleted Keep only finished trips (datef not empty)
+         * @param  int    $tripId        Restrict to a single trip (ActionComm id); 0 = all trips
+         * @return array                 List of trips as associative arrays, newest first
+         */
+        public static function fetchTrips($db, $object, bool $onlyCompleted = true, int $tripId = 0): array
+        {
+            global $conf;
+
+            require_once DOL_DOCUMENT_ROOT . '/comm/action/class/actioncomm.class.php';
+            require_once DOL_DOCUMENT_ROOT . '/core/lib/files.lib.php';
+
+            $trips = [];
+            if (empty($object->fk_lot)) {
+                return $trips;
+            }
+
+            $actionCommHelper = new ActionComm($db);
+            $allTrips         = $actionCommHelper->getActions(
+                0,
+                (int) $object->fk_lot,
+                'productlot',
+                ' AND fk_element = ' . (int) $object->fk_lot . ' AND code = "AC_PRODUCTLOT_ADD_PUBLIC_VEHICLE_LOG_BOOK"',
+                'datep',
+                'DESC'
+            );
+            if (!is_array($allTrips)) {
+                return $trips;
+            }
+
+            $dirOutput   = !empty($conf->dolicar->multidir_output[$conf->entity]) ? $conf->dolicar->multidir_output[$conf->entity] : $conf->dolicar->dir_output;
+            $imageFilter = '(\.jpg|\.jpeg|\.png|\.gif|\.webp)';
+
+            foreach ($allTrips as $trip) {
+                if ($tripId > 0 && (int) $trip->id !== $tripId) {
+                    continue;
+                }
+                if ($onlyCompleted && empty($trip->datef)) {
+                    continue;
+                }
+                $trip->fetch_optionals();
+                $json = json_decode($trip->array_options['options_json'] ?? '{}', true);
+                if (!is_array($json)) {
+                    $json = [];
+                }
+
+                $tripDir      = $dirOutput . '/vehicle_trip/' . (int) $trip->id;
+                $departPhotos = self::listImages($tripDir . '/depart', $imageFilter);
+                $returnPhotos = self::listImages($tripDir . '/retour', $imageFilter);
+                // Trips recorded before issue #457 keep their photos loose in the trip dir
+                $legacyPhotos = (empty($departPhotos) && empty($returnPhotos)) ? self::listImages($tripDir, $imageFilter) : [];
+
+                $trips[] = [
+                    'id'                => (int) $trip->id,
+                    'datep'             => $trip->datep,
+                    'datef'             => $trip->datef,
+                    'driver'            => $json['driver'] ?? '',
+                    'start_comment'     => $json['start_comment'] ?? '',
+                    'end_comment'       => $json['end_comment'] ?? '',
+                    'fuel_level'        => $json['fuel_level'] ?? '',
+                    'return_fuel_level' => $json['return_fuel_level'] ?? '',
+                    'starting_mileage'  => (int) ($trip->array_options['options_starting_mileage'] ?? 0),
+                    'arrival_mileage'   => (int) ($trip->array_options['options_arrival_mileage'] ?? 0),
+                    'depart_photos'     => $departPhotos,
+                    'return_photos'     => $returnPhotos,
+                    'legacy_photos'     => $legacyPhotos,
+                    'start_signature'   => null,
+                    'end_signature'     => null,
+                ];
+            }
+
+            self::attachSignatures($db, $trips);
+
+            return $trips;
+        }
+
+        /**
+         * Fill start_signature / end_signature for each trip from the Saturne signature table.
+         * Within a trip, signatures are ordered by rowid: the first is the départure signature,
+         * the second the return one. Exact duplicates (multiple submissions) are skipped.
+         *
+         * @param  DoliDB $db    Database handler
+         * @param  array  $trips Trips (passed by reference, mutated in place)
+         * @return void
+         */
+        private static function attachSignatures($db, array &$trips): void
+        {
+            if (empty($trips)) {
+                return;
+            }
+            $tripIds = array_map(static function ($t) {
+                return $t['id'];
+            }, $trips);
+
+            $sql  = 'SELECT fk_object, signature';
+            $sql .= ' FROM ' . MAIN_DB_PREFIX . 'saturne_object_signature';
+            $sql .= " WHERE object_type = 'actiocomm'";
+            $sql .= " AND module_name = 'dolicar'";
+            $sql .= ' AND status > 0';
+            $sql .= " AND signature LIKE 'data:image%'";
+            $sql .= ' AND fk_object IN (' . implode(',', $tripIds) . ')';
+            $sql .= ' ORDER BY fk_object ASC, rowid ASC';
+
+            $resql = $db->query($sql);
+            if (!$resql) {
+                return;
+            }
+
+            $byTrip = [];
+            while ($sig = $db->fetch_object($resql)) {
+                $parts = explode(',', $sig->signature, 2);
+                if (empty($parts[1])) {
+                    continue;
+                }
+                $binary = base64_decode($parts[1]);
+                if (empty($binary)) {
+                    continue;
+                }
+                $hash = md5($binary);
+                if (isset($byTrip[$sig->fk_object]['hashes'][$hash])) {
+                    continue;
+                }
+                $byTrip[$sig->fk_object]['hashes'][$hash] = true;
+                $byTrip[$sig->fk_object]['list'][]        = $binary;
+            }
+
+            foreach ($trips as &$trip) {
+                $list                   = $byTrip[$trip['id']]['list'] ?? [];
+                $trip['start_signature'] = $list[0] ?? null;
+                $trip['end_signature']   = $list[1] ?? null;
+            }
+            unset($trip);
+        }
+
+        /**
+         * List image files in a directory as absolute paths (sorted by name).
+         *
+         * @param  string $dir    Directory to scan
+         * @param  string $filter dol_dir_list name filter (regex fragment)
+         * @return array          List of absolute file paths
+         */
+        private static function listImages(string $dir, string $filter): array
+        {
+            if (!is_dir($dir)) {
+                return [];
+            }
+            $files = dol_dir_list($dir, 'files', 0, $filter, '', 'name', SORT_ASC);
+            $paths = [];
+            foreach ($files as $file) {
+                $paths[] = $file['fullname'];
+            }
+            return $paths;
+        }
     }
 }

--- a/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclephotossheet.modules.php
+++ b/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclephotossheet.modules.php
@@ -1,0 +1,239 @@
+<?php
+/* Copyright (C) 2022-2024 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclephotossheet.modules.php
+ * \ingroup dolicar
+ * \brief   File of class to build the vehicle departure/return photos sheet (native TCPDF)
+ */
+
+// Load Dolibarr libraries
+require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+
+// Load DoliCar shared PDF renderer and data helpers
+require_once __DIR__ . '/../dolicar_pdf_document.php';
+
+/**
+ * Class to build the vehicle photos sheet (departure / return photos, one section per trip)
+ */
+class pdf_vehiclephotossheet
+{
+    /**
+     * @var DoliDB Database handler
+     */
+    public $db;
+
+    /**
+     * @var string Model name
+     */
+    public $name;
+
+    /**
+     * @var string Model description (short text)
+     */
+    public $description;
+
+    /**
+     * @var string Document type
+     */
+    public $type;
+
+    /**
+     * @var array Minimum version of PHP required by module
+     */
+    public $phpmin = [7, 0];
+
+    /**
+     * @var string Dolibarr version of the loaded document
+     */
+    public $version = 'dolibarr';
+
+    /**
+     * @var string Module
+     */
+    public string $module = 'dolicar';
+
+    /**
+     * @var string Document type
+     */
+    public string $document_type = 'vehiclelogbookdocument';
+
+    /**
+     * @var int Let Dolibarr core update last_main_doc after generation
+     */
+    public $update_main_doc_field = 1;
+
+    /**
+     * @var array Result of the generation (fullpath is read by commonGenerateDocument)
+     */
+    public $result = [];
+
+    /**
+     * @var string Last error message
+     */
+    public $error = '';
+
+    /**
+     * Constructor
+     *
+     * @param DoliDB $db Database handler
+     */
+    public function __construct($db)
+    {
+        global $langs;
+
+        $this->db          = $db;
+        $this->name        = 'vehiclephotossheet';
+        $this->description = $langs->trans('VehiclePhotosSheetPDFDescription');
+        $this->type        = 'pdf';
+    }
+
+    /**
+     * Function to build a document on disk
+     *
+     * @param  SaturneDocuments $objectDocument  Object source to build document
+     * @param  Translate        $outputLangs     Lang object to use for output
+     * @param  string           $srcTemplatePath Full path of source filename for generator using a template file
+     * @param  int              $hideDetails     Do not show line details
+     * @param  int              $hideDesc        Do not show desc
+     * @param  int              $hideRef         Do not show ref
+     * @param  array            $moreParam       More param (Object/user/etc)
+     * @return int                               1 if OK, <=0 if KO
+     * @throws Exception
+     */
+    public function write_file($objectDocument, Translate $outputLangs, string $srcTemplatePath, int $hideDetails = 0, int $hideDesc = 0, int $hideRef = 0, array $moreParam = []): int
+    {
+        global $conf, $mysoc;
+
+        if (empty($moreParam) && is_object($objectDocument) && !empty($objectDocument->context['moreparams'])) {
+            $moreParam = $objectDocument->context['moreparams'];
+        }
+
+        $object = $moreParam['object'] ?? null;
+        if (!is_object($object)) {
+            $this->error = 'Missing source object for vehicle photos sheet generation';
+            return -1;
+        }
+
+        $outputLangs->loadLangs(['dolicar@dolicar', 'main', 'companies']);
+
+        $productLot = new ProductLot($this->db);
+        if (!empty($object->fk_lot)) {
+            $productLot->fetch((int) $object->fk_lot);
+        }
+
+        // Only completed trips carry both departure and return photos
+        $trips = DolicarPdfData::fetchTrips($this->db, $object, true);
+
+        $companyName = !empty($mysoc->name) ? $mysoc->name : getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
+
+        /*
+         * Build the PDF (native TCPDF, fixed columns)
+         */
+        $pdf              = new DolicarPdfTcpdf('P', 'mm', 'A4', true, 'UTF-8', false);
+        $pdf->logoPath    = DOL_DATA_ROOT . '/mycompany/logos/' . getDolGlobalString('MAIN_INFO_SOCIETE_LOGO');
+        $pdf->docTitle    = $outputLangs->transnoentities('VehiclePhotosSheet');
+        $pdf->docSubtitle = ($object->a_registration_number ?: $object->ref) . ' · ' . $outputLangs->transnoentities('EditedOn') . ' ' . dol_print_date(dol_now(), 'day');
+        $pdf->footerLegal = $companyName . ' · ' . dol_print_date(dol_now(), 'day');
+
+        $pdf->SetCreator('DoliCar');
+        $pdf->SetAuthor($companyName);
+        $pdf->SetTitle($pdf->docTitle . ' - ' . $object->ref);
+        $pdf->SetMargins(15, 36, 15);
+        $pdf->SetHeaderMargin(5);
+        $pdf->SetFooterMargin(12);
+        $pdf->SetAutoPageBreak(false, 18);
+        $pdf->AddPage();
+
+        $render = new DolicarPdfRender($pdf, 15, 15);
+
+        if (empty($trips)) {
+            $render->sectionTitle($outputLangs->transnoentities('VehiclePhotos'));
+            $render->photoGrid([], $outputLangs->transnoentities('NoCompletedTrip'));
+        }
+
+        $first = true;
+        foreach ($trips as $trip) {
+            // Each trip starts on a fresh page so its départ/retour photos stay grouped together
+            if (!$first) {
+                $pdf->AddPage();
+            }
+            $first = false;
+
+            $render->sectionTitle($outputLangs->transnoentities('TripOf', dol_print_date($trip['datep'], 'day')));
+            $render->keyValueGrid([
+                [$outputLangs->transnoentities('LicensePlate'), $object->a_registration_number ?? ''],
+                [$outputLangs->transnoentities('Driver'), $trip['driver']],
+                [$outputLangs->transnoentities('DepartureDate'), dol_print_date($trip['datep'], 'dayhour')],
+                [$outputLangs->transnoentities('ReturnDate'), dol_print_date($trip['datef'], 'dayhour')],
+            ]);
+            $render->spacer(3);
+
+            if (!empty($trip['legacy_photos'])) {
+                // Trip recorded before the départ/retour split: a single combined section
+                $render->sectionTitle($outputLangs->transnoentities('TripPhotos'));
+                $render->photoGrid($trip['legacy_photos'], $outputLangs->transnoentities('NoPhoto'));
+                $render->spacer(4);
+                continue;
+            }
+
+            $render->sectionTitle($outputLangs->transnoentities('PhotosDeparture'));
+            $render->photoGrid($trip['depart_photos'], $outputLangs->transnoentities('NoPhoto'));
+            $render->spacer(4);
+
+            $render->sectionTitle($outputLangs->transnoentities('PhotosReturn'));
+            $render->photoGrid($trip['return_photos'], $outputLangs->transnoentities('NoPhoto'));
+            $render->spacer(4);
+        }
+
+        /*
+         * Save the file
+         */
+        $dirOutput = !empty($conf->dolicar->multidir_output[$conf->entity]) ? $conf->dolicar->multidir_output[$conf->entity] : $conf->dolicar->dir_output;
+        if (empty($dirOutput)) {
+            $this->error = 'Configuration manquante: conf->dolicar->dir_output';
+            return -1;
+        }
+        $dir = $dirOutput . '/vehiclelogbookdocument/' . dol_sanitizeFileName($object->ref);
+        if (!file_exists($dir) && dol_mkdir($dir) < 0) {
+            $this->error = 'Impossible de créer le répertoire: ' . $dir;
+            return -1;
+        }
+
+        $fileName = dol_sanitizeFileName(dol_print_date(dol_now(), '%Y%m%d') . '-' . $object->ref . '-fiche-photos') . '.pdf';
+        $file     = $dir . '/' . $fileName;
+
+        try {
+            $pdf->Output($file, 'F');
+        } catch (Exception $exception) {
+            $this->error = 'Erreur lors de la création du PDF : ' . $exception->getMessage();
+            return -1;
+        }
+        if (!file_exists($file)) {
+            $this->error = 'PDF non généré (fichier introuvable après Output) : ' . $file;
+            return -1;
+        }
+
+        if (!empty($conf->global->MAIN_UMASK)) {
+            @chmod($file, octdec($conf->global->MAIN_UMASK));
+        }
+
+        $this->result = ['fullpath' => $file];
+
+        return 1;
+    }
+}

--- a/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php
+++ b/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php
@@ -1,0 +1,256 @@
+<?php
+/* Copyright (C) 2022-2024 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php
+ * \ingroup dolicar
+ * \brief   File of class to build the vehicle "before / after" state sheet (native TCPDF)
+ */
+
+// Load Dolibarr libraries
+require_once DOL_DOCUMENT_ROOT . '/product/stock/class/productlot.class.php';
+require_once DOL_DOCUMENT_ROOT . '/societe/class/societe.class.php';
+
+// Load DoliCar shared PDF renderer and data helpers
+require_once __DIR__ . '/../dolicar_pdf_document.php';
+
+/**
+ * Class to build the vehicle "before / after" state sheet (one départ/retour block per trip)
+ */
+class pdf_vehiclestatesheet
+{
+    /**
+     * @var DoliDB Database handler
+     */
+    public $db;
+
+    /**
+     * @var string Model name
+     */
+    public $name;
+
+    /**
+     * @var string Model description (short text)
+     */
+    public $description;
+
+    /**
+     * @var string Document type
+     */
+    public $type;
+
+    /**
+     * @var array Minimum version of PHP required by module
+     */
+    public $phpmin = [7, 0];
+
+    /**
+     * @var string Dolibarr version of the loaded document
+     */
+    public $version = 'dolibarr';
+
+    /**
+     * @var string Module
+     */
+    public string $module = 'dolicar';
+
+    /**
+     * @var string Document type
+     */
+    public string $document_type = 'vehiclelogbookdocument';
+
+    /**
+     * @var int Let Dolibarr core update last_main_doc after generation
+     */
+    public $update_main_doc_field = 1;
+
+    /**
+     * @var array Result of the generation (fullpath is read by commonGenerateDocument)
+     */
+    public $result = [];
+
+    /**
+     * @var string Last error message
+     */
+    public $error = '';
+
+    /**
+     * Constructor
+     *
+     * @param DoliDB $db Database handler
+     */
+    public function __construct($db)
+    {
+        global $langs;
+
+        $this->db          = $db;
+        $this->name        = 'vehiclestatesheet';
+        $this->description = $langs->trans('VehicleStateSheetPDFDescription');
+        $this->type        = 'pdf';
+    }
+
+    /**
+     * Function to build a document on disk
+     *
+     * @param  SaturneDocuments $objectDocument  Object source to build document
+     * @param  Translate        $outputLangs     Lang object to use for output
+     * @param  string           $srcTemplatePath Full path of source filename for generator using a template file
+     * @param  int              $hideDetails     Do not show line details
+     * @param  int              $hideDesc        Do not show desc
+     * @param  int              $hideRef         Do not show ref
+     * @param  array            $moreParam       More param (Object/user/etc)
+     * @return int                               1 if OK, <=0 if KO
+     * @throws Exception
+     */
+    public function write_file($objectDocument, Translate $outputLangs, string $srcTemplatePath, int $hideDetails = 0, int $hideDesc = 0, int $hideRef = 0, array $moreParam = []): int
+    {
+        global $conf, $mysoc, $user;
+
+        if (empty($moreParam) && is_object($objectDocument) && !empty($objectDocument->context['moreparams'])) {
+            $moreParam = $objectDocument->context['moreparams'];
+        }
+
+        $object = $moreParam['object'] ?? null;
+        if (!is_object($object)) {
+            $this->error = 'Missing source object for vehicle state sheet generation';
+            return -1;
+        }
+
+        $outputLangs->loadLangs(['dolicar@dolicar', 'main', 'companies']);
+
+        $thirdParty = new Societe($this->db);
+        if (!empty($object->fk_soc)) {
+            $thirdParty->fetch($object->fk_soc);
+        }
+
+        $productLot = new ProductLot($this->db);
+        if (!empty($object->fk_lot)) {
+            $productLot->fetch((int) $object->fk_lot);
+        }
+
+        $fuelLabels = [
+            'reserve'       => $outputLangs->transnoentities('FuelReserve'),
+            'quarter'       => '1/4',
+            'half'          => '1/2',
+            'threequarters' => '3/4',
+            'full'          => $outputLangs->transnoentities('FuelFull'),
+        ];
+
+        // A single trip can be requested (per-trip download from the public PWA history list)
+        $tripId = (int) ($moreParam['trip_id'] ?? 0);
+
+        // Only completed trips (departure + return) carry a meaningful before/after comparison
+        $trips = DolicarPdfData::fetchTrips($this->db, $object, true, $tripId);
+
+        $companyName = !empty($mysoc->name) ? $mysoc->name : getDolGlobalString('MAIN_INFO_SOCIETE_NOM');
+
+        /*
+         * Build the PDF (native TCPDF, fixed columns)
+         */
+        $pdf              = new DolicarPdfTcpdf('P', 'mm', 'A4', true, 'UTF-8', false);
+        $pdf->logoPath    = DOL_DATA_ROOT . '/mycompany/logos/' . getDolGlobalString('MAIN_INFO_SOCIETE_LOGO');
+        $pdf->docTitle    = $outputLangs->transnoentities('VehicleStateSheet');
+        $pdf->docSubtitle = ($object->a_registration_number ?: $object->ref) . ' · ' . $outputLangs->transnoentities('EditedOn') . ' ' . dol_print_date(dol_now(), 'day');
+        $pdf->footerLegal = $companyName . ' · ' . dol_print_date(dol_now(), 'day');
+
+        $pdf->SetCreator('DoliCar');
+        $pdf->SetAuthor($companyName);
+        $pdf->SetTitle($pdf->docTitle . ' - ' . $object->ref);
+        $pdf->SetMargins(15, 36, 15);
+        $pdf->SetHeaderMargin(5);
+        $pdf->SetFooterMargin(12);
+        $pdf->SetAutoPageBreak(false, 18);
+        $pdf->AddPage();
+
+        $render = new DolicarPdfRender($pdf, 15, 15);
+
+        // Vehicle information
+        $render->sectionTitle($outputLangs->transnoentities('Vehicle'));
+        $render->keyValueGrid([
+            [$outputLangs->transnoentities('Ref'), $object->ref],
+            [$outputLangs->transnoentities('LicensePlate'), $object->a_registration_number ?? ''],
+            [$outputLangs->transnoentities('BrandAndModel'), trim(($object->d1_vehicle_brand ?? '') . ' ' . ($object->d3_vehicle_model ?? ''))],
+            [$outputLangs->transnoentities('VinOrLotNumber'), !empty($productLot->batch) ? $productLot->batch : ''],
+            [$outputLangs->transnoentities('Fuel'), $object->p3_fuel_type ?? ''],
+            [$outputLangs->transnoentities('OwnerThirdParty'), !empty($thirdParty->name) ? $thirdParty->name : ''],
+        ]);
+        $render->spacer(4);
+
+        if (empty($trips)) {
+            $render->sectionTitle($outputLangs->transnoentities('VehicleStateBeforeAfter'));
+            $render->photoGrid([], $outputLangs->transnoentities('NoCompletedTrip'));
+        }
+
+        foreach ($trips as $trip) {
+            $render->sectionTitle($outputLangs->transnoentities('TripOf', dol_print_date($trip['datep'], 'day')));
+
+            $kmStart = $trip['starting_mileage'] > 0 ? number_format($trip['starting_mileage'], 0, ',', ' ') . ' km' : '';
+            $kmEnd   = $trip['arrival_mileage'] > 0 ? number_format($trip['arrival_mileage'], 0, ',', ' ') . ' km' : '';
+
+            $render->beforeAfterGrid(
+                $outputLangs->transnoentities('Departure'),
+                $outputLangs->transnoentities('Return'),
+                [
+                    ['label' => $outputLangs->transnoentities('Date'),     'left' => dol_print_date($trip['datep'], 'dayhour'),                 'right' => dol_print_date($trip['datef'], 'dayhour')],
+                    ['label' => $outputLangs->transnoentities('Driver'),   'left' => $trip['driver'],                                          'right' => $trip['driver']],
+                    ['label' => $outputLangs->transnoentities('Mileage'),  'left' => $kmStart,                                                 'right' => $kmEnd],
+                    ['label' => $outputLangs->transnoentities('Fuel'),     'left' => $fuelLabels[$trip['fuel_level']] ?? '',                   'right' => $fuelLabels[$trip['return_fuel_level']] ?? ''],
+                    ['label' => $outputLangs->transnoentities('Comments'), 'left' => $trip['start_comment'],                                   'right' => $trip['end_comment']],
+                    ['label' => $outputLangs->transnoentities('Signature'), 'image' => true, 'leftImg' => $trip['start_signature'], 'rightImg' => $trip['end_signature']],
+                ]
+            );
+            $render->spacer(5);
+        }
+
+        /*
+         * Save the file
+         */
+        $dirOutput = !empty($conf->dolicar->multidir_output[$conf->entity]) ? $conf->dolicar->multidir_output[$conf->entity] : $conf->dolicar->dir_output;
+        if (empty($dirOutput)) {
+            $this->error = 'Configuration manquante: conf->dolicar->dir_output';
+            return -1;
+        }
+        $dir = $dirOutput . '/vehiclelogbookdocument/' . dol_sanitizeFileName($object->ref);
+        if (!file_exists($dir) && dol_mkdir($dir) < 0) {
+            $this->error = 'Impossible de créer le répertoire: ' . $dir;
+            return -1;
+        }
+
+        $fileSuffix = $tripId > 0 ? '-fiche-etat-trajet-' . $tripId : '-fiche-etat';
+        $fileName   = dol_sanitizeFileName(dol_print_date(dol_now(), '%Y%m%d') . '-' . $object->ref . $fileSuffix) . '.pdf';
+        $file       = $dir . '/' . $fileName;
+
+        try {
+            $pdf->Output($file, 'F');
+        } catch (Exception $exception) {
+            $this->error = 'Erreur lors de la création du PDF : ' . $exception->getMessage();
+            return -1;
+        }
+        if (!file_exists($file)) {
+            $this->error = 'PDF non généré (fichier introuvable après Output) : ' . $file;
+            return -1;
+        }
+
+        if (!empty($conf->global->MAIN_UMASK)) {
+            @chmod($file, octdec($conf->global->MAIN_UMASK));
+        }
+
+        $this->result = ['fullpath' => $file];
+
+        return 1;
+    }
+}

--- a/core/modules/modDoliCar.class.php
+++ b/core/modules/modDoliCar.class.php
@@ -803,6 +803,13 @@ class modDoliCar extends DolibarrModules
         delDocumentModel('vehiclelogbookdocument', 'vehiclelogbookdocument');
         addDocumentModel('vehiclelogbookdocument', 'vehiclelogbookdocument', $langs->transnoentities('VehicleLogBookDocument') . '.pdf');
 
+        // Before/after state sheet and departure/return photos sheet (issue #457)
+        delDocumentModel('vehiclestatesheet', 'vehiclelogbookdocument');
+        addDocumentModel('vehiclestatesheet', 'vehiclelogbookdocument', $langs->transnoentities('VehicleStateSheet') . '.pdf');
+
+        delDocumentModel('vehiclephotossheet', 'vehiclelogbookdocument');
+        addDocumentModel('vehiclephotossheet', 'vehiclelogbookdocument', $langs->transnoentities('VehiclePhotosSheet') . '.pdf');
+
         return $this->_init($sql, $options);
     }
 }

--- a/core/tpl/public_vehicle_logbook_bottombar.tpl.php
+++ b/core/tpl/public_vehicle_logbook_bottombar.tpl.php
@@ -46,6 +46,18 @@
         </span>
     <?php endif; ?>
     <?php if ($currentVehicleId > 0) : ?>
+        <a href="<?php echo $_SERVER['PHP_SELF'] . '?id=' . $currentVehicleId . '&entity=' . urlencode($entity) . '&view=history'; ?>"
+           class="plv2-bottombar__item<?php echo $showScreen === 'history' ? ' plv2-bottombar__item--active' : ''; ?>">
+            <i class="fas fa-history"></i>
+            <span><?php echo $langs->trans('BottomBarHistory'); ?></span>
+        </a>
+    <?php else : ?>
+        <span class="plv2-bottombar__item plv2-bottombar__item--disabled">
+            <i class="fas fa-history"></i>
+            <span><?php echo $langs->trans('BottomBarHistory'); ?></span>
+        </span>
+    <?php endif; ?>
+    <?php if ($currentVehicleId > 0) : ?>
         <a href="<?php echo $_SERVER['PHP_SELF'] . '?id=' . $currentVehicleId . '&entity=' . urlencode($entity) . '&action_type=reparation'; ?>"
            class="plv2-bottombar__item<?php echo $showScreen === 'repair' ? ' plv2-bottombar__item--active' : ''; ?>">
             <i class="fas fa-wrench"></i>

--- a/core/tpl/public_vehicle_logbook_history.tpl.php
+++ b/core/tpl/public_vehicle_logbook_history.tpl.php
@@ -123,8 +123,8 @@ $historyUrl = $_SERVER['PHP_SELF'] . '?id=' . $id . '&entity=' . urlencode($enti
                     <?php endif; ?>
 
                     <?php if (!$acIsOpen) : ?>
-                        <a class="plv2-history-item__download" href="<?php echo $historyUrl . '&action=download_trip_pdf&trip_id=' . (int) $ac->id; ?>">
-                            <i class="fas fa-file-pdf"></i> <?php echo $langs->trans('DownloadStateSheet'); ?>
+                        <a class="plv2-history-item__download" href="<?php echo $historyUrl . '&action=view_trip_pdf&trip_id=' . (int) $ac->id; ?>" target="_blank" rel="noopener">
+                            <i class="fas fa-file-pdf"></i> <?php echo $langs->trans('ViewStateSheet'); ?>
                         </a>
                     <?php endif; ?>
                 </div>

--- a/core/tpl/public_vehicle_logbook_history.tpl.php
+++ b/core/tpl/public_vehicle_logbook_history.tpl.php
@@ -1,0 +1,134 @@
+<?php
+/* Copyright (C) 2024-2025 EVARISK <technique@evarisk.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file    core/tpl/public_vehicle_logbook_history.tpl.php
+ * \ingroup dolicar
+ * \brief   Public vehicle logbook — full trips history (departures/returns) with per-trip PDF download
+ */
+
+/**
+ * Rendered by public/agenda/public_vehicle_logbook.php (inherits its scope).
+ * Expects: $logoUrl, $langs, $registrationCertificateFR, $historyTrips, $id, $entity, $conf
+ */
+
+$fuelIcons  = ['reserve' => 'fa-battery-empty', 'quarter' => 'fa-battery-quarter', 'half' => 'fa-battery-half', 'threequarters' => 'fa-battery-three-quarters', 'full' => 'fa-battery-full'];
+$fuelLabels = ['reserve' => $langs->trans('FuelReserve'), 'quarter' => '1/4', 'half' => '1/2', 'threequarters' => '3/4', 'full' => $langs->trans('FuelFull')];
+$historyUrl = $_SERVER['PHP_SELF'] . '?id=' . $id . '&entity=' . urlencode($entity);
+?>
+<!-- ===== SCREEN : historique complet des prises / rendus ===== -->
+<div class="plv2-header plv2-header--dark">
+    <div class="plv2-header__top">
+        <div class="plv2-header__logo">
+            <img src="<?php echo $logoUrl; ?>" alt="DoliCar" class="plv2-header__logo-img">
+            <div class="plv2-header__logo-text">
+                DoliCar
+                <small><?php echo $langs->trans('VehicleTripHistory'); ?></small>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="plv2-content">
+    <div class="plv2-history-head">
+        <span class="plv2-plate-badge"><?php echo dol_escape_htmltag($registrationCertificateFR->a_registration_number); ?></span>
+        <span class="plv2-history-head__count"><?php echo count($historyTrips); ?> <?php echo $langs->trans('Trips'); ?></span>
+    </div>
+
+    <?php if (empty($historyTrips)) : ?>
+        <div class="plv2-empty">
+            <i class="fas fa-route"></i>
+            <p><?php echo $langs->trans('NoTripRecorded'); ?></p>
+        </div>
+    <?php else : ?>
+        <div class="plv2-history">
+            <?php foreach ($historyTrips as $ac) :
+                $acJson            = json_decode($ac->array_options['options_json'] ?? '{}', true);
+                $acDriver          = $acJson['driver'] ?? '—';
+                $acIsOpen          = empty($ac->datef);
+                $acKmStart         = $ac->array_options['options_starting_mileage'] ?? null;
+                $acKmEnd           = $ac->array_options['options_arrival_mileage'] ?? null;
+                $acFuelLevel       = $acJson['fuel_level'] ?? null;
+                $acReturnFuelLevel = $acJson['return_fuel_level'] ?? null;
+                $acStartComment    = $acJson['start_comment'] ?? null;
+                $acEndComment      = $acJson['end_comment'] ?? null;
+            ?>
+                <div class="plv2-history-item">
+                    <div class="plv2-history-item__head">
+                        <div class="plv2-history-item__driver">
+                            <i class="fas fa-user-circle"></i>
+                            <?php echo dol_escape_htmltag($acDriver); ?>
+                        </div>
+                        <span class="plv2-badge <?php echo $acIsOpen ? 'plv2-badge--out' : 'plv2-badge--done'; ?>">
+                            <?php echo $acIsOpen ? $langs->trans('TripInProgress') : $langs->trans('TripDone'); ?>
+                        </span>
+                    </div>
+                    <div class="plv2-history-item__row">
+                        <span class="plv2-history-item__type plv2-history-item__type--depart">
+                            <i class="fas fa-sign-out-alt"></i> <?php echo $langs->trans('Departure'); ?>
+                        </span>
+                        <span><?php echo dol_print_date($ac->datep, 'dayhour'); ?></span>
+                        <?php if (!empty($acKmStart)) : ?>
+                            <span class="plv2-history-item__km"><?php echo number_format((int) $acKmStart, 0, ',', ' ') . ' km'; ?></span>
+                        <?php endif; ?>
+                        <?php if (!empty($acFuelLevel) && isset($fuelIcons[$acFuelLevel])) : ?>
+                            <span class="plv2-history-item__fuel">
+                                <i class="fas <?php echo $fuelIcons[$acFuelLevel]; ?>"></i>
+                                <?php echo $fuelLabels[$acFuelLevel]; ?>
+                            </span>
+                        <?php endif; ?>
+                    </div>
+                    <?php if (!empty($acStartComment)) : ?>
+                        <div class="plv2-history-item__comment">
+                            <i class="fas fa-comment-dots"></i>
+                            <?php echo dol_escape_htmltag($acStartComment); ?>
+                        </div>
+                    <?php endif; ?>
+                    <?php if (!$acIsOpen) : ?>
+                        <div class="plv2-history-item__row">
+                            <span class="plv2-history-item__type plv2-history-item__type--retour">
+                                <i class="fas fa-sign-in-alt"></i> <?php echo $langs->trans('Return'); ?>
+                            </span>
+                            <span><?php echo dol_print_date($ac->datef, 'dayhour'); ?></span>
+                            <?php if (!empty($acKmEnd)) : ?>
+                                <span class="plv2-history-item__km"><?php echo number_format((int) $acKmEnd, 0, ',', ' ') . ' km'; ?></span>
+                            <?php endif; ?>
+                            <?php if (!empty($acReturnFuelLevel) && isset($fuelIcons[$acReturnFuelLevel])) : ?>
+                                <span class="plv2-history-item__fuel">
+                                    <i class="fas <?php echo $fuelIcons[$acReturnFuelLevel]; ?>"></i>
+                                    <?php echo $fuelLabels[$acReturnFuelLevel]; ?>
+                                </span>
+                            <?php endif; ?>
+                        </div>
+                        <?php if (!empty($acEndComment)) : ?>
+                            <div class="plv2-history-item__comment">
+                                <i class="fas fa-comment-dots"></i>
+                                <?php echo dol_escape_htmltag($acEndComment); ?>
+                            </div>
+                        <?php endif; ?>
+                    <?php endif; ?>
+
+                    <?php if (!$acIsOpen) : ?>
+                        <a class="plv2-history-item__download" href="<?php echo $historyUrl . '&action=download_trip_pdf&trip_id=' . (int) $ac->id; ?>">
+                            <i class="fas fa-file-pdf"></i> <?php echo $langs->trans('DownloadStateSheet'); ?>
+                        </a>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</div>

--- a/core/tpl/public_vehicle_logbook_success.tpl.php
+++ b/core/tpl/public_vehicle_logbook_success.tpl.php
@@ -23,7 +23,7 @@
 
 /**
  * Rendered by public/agenda/public_vehicle_logbook.php (inherits its scope).
- * Expects: $isVehicleOut, $lastUnfinishedActionComm, $lastActionComm, $langs, $registrationCertificateFR, $vehicleUrl, $baseUrl
+ * Expects: $isVehicleOut, $lastUnfinishedActionComm, $lastActionComm, $langs, $registrationCertificateFR, $vehicleUrl
  */
 
 $problemSuccess  = GETPOSTINT('problem');
@@ -88,9 +88,6 @@ $successAction   = $successIsDepart ? ($lastUnfinishedActionComm[0] ?? null) : (
 
     <div class="plv2-success__actions">
         <a href="<?php echo $vehicleUrl; ?>" class="plv2-btn plv2-btn--primary plv2-btn--full">
-            <?php echo $langs->trans('NewEntry'); ?>
-        </a>
-        <a href="<?php echo $baseUrl; ?>" class="plv2-btn plv2-btn--ghost plv2-btn--full">
             <?php echo $langs->trans('ClosePublicLogBook'); ?>
         </a>
     </div>

--- a/core/tpl/public_vehicle_logbook_vehicle.tpl.php
+++ b/core/tpl/public_vehicle_logbook_vehicle.tpl.php
@@ -198,7 +198,8 @@
                     $acPhotoCount = 0;
                     $acAudioCount = 0;
                     if (dol_is_dir($acMediaDir)) {
-                        foreach (dol_dir_list($acMediaDir, 'files', 0, '', '(\.meta|_preview.*\.png)$') as $acMediaFile) {
+                        // Recursive: trip media now live in depart/ and retour/ subfolders (issue #457)
+                        foreach (dol_dir_list($acMediaDir, 'files', 1, '', '(\.meta|_preview.*\.png)$') as $acMediaFile) {
                             if (image_format_supported($acMediaFile['name']) >= 0) {
                                 $acPhotoCount++;
                             } elseif (preg_match('/\.(wav|mp3|ogg|m4a)$/i', $acMediaFile['name'])) {
@@ -220,5 +221,8 @@
                 </div>
             <?php endforeach; ?>
         </div>
+        <a class="plv2-history-seeall" href="<?php echo $vehicleUrl . '&view=history'; ?>">
+            <i class="fas fa-history"></i> <?php echo $langs->trans('SeeAllTripHistory'); ?>
+        </a>
     <?php endif; ?>
 </div>

--- a/css/dolicar.min.css
+++ b/css/dolicar.min.css
@@ -1037,6 +1037,72 @@
   margin-top: 1px;
   flex-shrink: 0;
 }
+.page-public-card .plv2-app .plv2-history-item__download {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin-top: 10px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  background: #1571d3;
+  color: #fff;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.page-public-card .plv2-app .plv2-history-item__download i {
+  font-size: 14px;
+}
+.page-public-card .plv2-app .plv2-history-item__download:active {
+  background: #115cad;
+}
+.page-public-card .plv2-app .plv2-history-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.page-public-card .plv2-app .plv2-history-head__count {
+  font-size: 12px;
+  font-weight: 600;
+  color: #5b6470;
+}
+.page-public-card .plv2-app .plv2-history-seeall {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin-bottom: 14px;
+  padding: 10px;
+  border-radius: 10px;
+  background: #fff;
+  border: 1px solid #d4d8de;
+  color: #1571d3;
+  font-size: 12.5px;
+  font-weight: 600;
+  text-decoration: none;
+}
+.page-public-card .plv2-app .plv2-history-seeall i {
+  font-size: 13px;
+}
+.page-public-card .plv2-app .plv2-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 40px 20px;
+  text-align: center;
+  color: #8a93a0;
+}
+.page-public-card .plv2-app .plv2-empty i {
+  font-size: 34px;
+  color: #c2c8d0;
+}
+.page-public-card .plv2-app .plv2-empty p {
+  margin: 0;
+  font-size: 13px;
+}
 .page-public-card .plv2-app .plv2-badge {
   font-size: 10px;
   font-weight: 700;

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -1068,6 +1068,70 @@
 
         i { color: #9ca3af; margin-top: 1px; flex-shrink: 0; }
       }
+
+      &__download {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 7px;
+        margin-top: 10px;
+        padding: 9px 12px;
+        border-radius: 10px;
+        background: #1571d3;
+        color: #fff;
+        font-size: 12.5px;
+        font-weight: 600;
+        text-decoration: none;
+
+        i { font-size: 14px; }
+
+        &:active { background: #115cad; }
+      }
+    }
+
+    // ── History screen (full trips list) ───────────────────────────────────
+    .plv2-history-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+
+      &__count {
+        font-size: 12px;
+        font-weight: 600;
+        color: #5b6470;
+      }
+    }
+
+    .plv2-history-seeall {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 7px;
+      margin-bottom: 14px;
+      padding: 10px;
+      border-radius: 10px;
+      background: #fff;
+      border: 1px solid #d4d8de;
+      color: #1571d3;
+      font-size: 12.5px;
+      font-weight: 600;
+      text-decoration: none;
+
+      i { font-size: 13px; }
+    }
+
+    .plv2-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 10px;
+      padding: 40px 20px;
+      text-align: center;
+      color: #8a93a0;
+
+      i { font-size: 34px; color: #c2c8d0; }
+      p { margin: 0; font-size: 13px; }
     }
 
     .plv2-badge {

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -282,6 +282,14 @@ TripInProgress               = En cours
 TripDone                     = Terminé
 ClosePublicLogBook           = Fermer
 
+# Public interface - Trajets (issue #457)
+BottomBarHistory             = Trajets
+VehicleTripHistory           = Trajets
+Trips                        = trajets
+NoTripRecorded               = Aucun trajet enregistré pour ce véhicule
+SeeAllTripHistory            = Voir tous les trajets
+DownloadStateSheet           = Télécharger la fiche état
+
 # Public interface - Réparation
 Repair               = Réparation
 BottomBarRepair      = Réparation
@@ -403,6 +411,20 @@ DepartureDate                        = Date départ
 ReturnDate                           = Date retour
 Comments                             = Commentaires
 Signatures                           = Signatures
+
+# PDF fiche état avant/après et fiche photos (issue #457)
+VehicleStateSheet                    = Fiche état avant/après
+VehiclePhotosSheet                   = Fiche détails photos
+VehicleStateSheetPDFDescription      = Modèle PDF de fiche état du véhicule (départ / retour)
+VehiclePhotosSheetPDFDescription     = Modèle PDF des photos du véhicule (départ / retour)
+VehicleStateBeforeAfter              = État du véhicule — Avant / Après
+TripOf                               = Trajet du %s
+PhotosDeparture                      = Photos départ
+PhotosReturn                         = Photos retour
+TripPhotos                           = Photos du trajet
+NoPhoto                              = Aucune photo
+NoCompletedTrip                      = Aucun trajet terminé
+Signature                            = Signature
 
 # Import - Import de cartes grises
 ImportRegistrationCertificate         = Importer des cartes grises

--- a/langs/fr_FR/dolicar.lang
+++ b/langs/fr_FR/dolicar.lang
@@ -288,7 +288,7 @@ VehicleTripHistory           = Trajets
 Trips                        = trajets
 NoTripRecorded               = Aucun trajet enregistré pour ce véhicule
 SeeAllTripHistory            = Voir tous les trajets
-DownloadStateSheet           = Télécharger la fiche état
+ViewStateSheet               = Voir la fiche état
 
 # Public interface - Réparation
 Repair               = Réparation

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -200,6 +200,32 @@ if ($resHook < 0) {
 }
 
 if (empty($resHook)) {
+    // Download the "before/after" state sheet PDF of a single trip (issue #457 — public history list)
+    if ($action == 'download_trip_pdf' && getDolGlobalInt('SATURNE_ENABLE_PUBLIC_INTERFACE')) {
+        $tripId    = GETPOSTINT('trip_id');
+        $tripCheck = new ActionComm($db);
+        // The trip must belong to this vehicle's lot and be a public logbook trip (no cross-vehicle access)
+        if ($tripId > 0 && $registrationCertificateFR->id > 0 && $tripCheck->fetch($tripId) > 0
+            && $tripCheck->code === 'AC_PRODUCTLOT_ADD_PUBLIC_VEHICLE_LOG_BOOK'
+            && (int) $tripCheck->fk_element === (int) $productLot->id) {
+            require_once __DIR__ . '/../../core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php';
+
+            $stateSheet = new pdf_vehiclestatesheet($db);
+            $genResult  = $stateSheet->write_file($registrationCertificateFR, $langs, '', 0, 0, 0, ['object' => $registrationCertificateFR, 'user' => $user, 'trip_id' => $tripId]);
+
+            if ($genResult > 0 && !empty($stateSheet->result['fullpath']) && is_file($stateSheet->result['fullpath'])) {
+                $pdfFile = $stateSheet->result['fullpath'];
+                top_httphead('application/pdf');
+                header('Content-Disposition: attachment; filename="' . basename($pdfFile) . '"');
+                header('Content-Length: ' . filesize($pdfFile));
+                readfile($pdfFile);
+                exit;
+            }
+        }
+        header('Location: ' . $_SERVER['PHP_SELF'] . '?id=' . $id . '&entity=' . $entity . '&view=history');
+        exit;
+    }
+
     // Problem report — photo upload posted by the Saturne media block (issue #443)
     if ($action == 'uploadPhoto' && !empty($conf->global->MAIN_UPLOAD_DOC)) {
         $uploadSubDir = GETPOST('sub_dir', 'alpha');
@@ -506,7 +532,11 @@ if (empty($resHook)) {
         if ($tripActionId > 0) {
             $tripMediaFiles = saturne_get_media_files('dolicar', $tripUploadSubDir);
             if (!empty($tripMediaFiles)) {
-                $tripFinalDir = $conf->dolicar->dir_output . '/vehicle_trip/' . (int) $tripActionId;
+                // Issue #457: keep départ and retour media in separate subfolders so the vehicle
+                // state/photos PDF can render them apart. Creating the trip = départ, updating the
+                // unfinished trip on return = retour.
+                $tripPhase    = isset($actionCommID) ? 'depart' : 'retour';
+                $tripFinalDir = $conf->dolicar->dir_output . '/vehicle_trip/' . (int) $tripActionId . '/' . $tripPhase;
                 if (!dol_is_dir($tripFinalDir)) {
                     dol_mkdir($tripFinalDir);
                 }
@@ -552,6 +582,8 @@ if ($success) {
     $successType = $isVehicleOut ? 'depart' : 'retour';
 } elseif ($view === 'list') {
     $showScreen = 'list';
+} elseif ($view === 'history' && $id > 0 && $registrationCertificateFR->id > 0) {
+    $showScreen = 'history';
 } elseif ($id > 0 && $registrationCertificateFR->id > 0) {
     if ($actionType === 'probleme') {
         $showScreen = 'problem';
@@ -596,7 +628,19 @@ if ($currentVehicleId > 0) {
 }
 
 // Bottom navigation bar — on the browsing screens plus the repair/control tabs (not on the depart/retour/problem/success flows)
-$showBottomBar = in_array($showScreen, ['search', 'list', 'vehicle', 'repair', 'control'], true);
+$showBottomBar = in_array($showScreen, ['search', 'list', 'vehicle', 'history', 'repair', 'control'], true);
+
+// History screen — full list of this vehicle's trips (departures/returns), newest first
+$historyTrips = [];
+if ($showScreen === 'history') {
+    $historyTrips = $actionComm->getActions(0, $id, 'productlot', ' AND fk_element = ' . $id . ' AND code = "AC_' . strtoupper($productLot->element) . '_ADD_PUBLIC_VEHICLE_LOG_BOOK"', 'datep', 'DESC');
+    if (!is_array($historyTrips)) {
+        $historyTrips = [];
+    }
+    foreach ($historyTrips as $historyTrip) {
+        $historyTrip->fetch_optionals();
+    }
+}
 
 // Public list of registration certificates (cards linking to ?id=fk_lot)
 $allCertificates = [];

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -200,8 +200,8 @@ if ($resHook < 0) {
 }
 
 if (empty($resHook)) {
-    // Download the "before/after" state sheet PDF of a single trip (issue #457 — public history list)
-    if ($action == 'download_trip_pdf' && getDolGlobalInt('SATURNE_ENABLE_PUBLIC_INTERFACE')) {
+    // View the "before/after" state sheet PDF of a single trip inline (issue #457 — public trips list)
+    if ($action == 'view_trip_pdf' && getDolGlobalInt('SATURNE_ENABLE_PUBLIC_INTERFACE')) {
         $tripId    = GETPOSTINT('trip_id');
         $tripCheck = new ActionComm($db);
         // The trip must belong to this vehicle's lot and be a public logbook trip (no cross-vehicle access)
@@ -215,8 +215,9 @@ if (empty($resHook)) {
 
             if ($genResult > 0 && !empty($stateSheet->result['fullpath']) && is_file($stateSheet->result['fullpath'])) {
                 $pdfFile = $stateSheet->result['fullpath'];
+                // inline so the browser PDF viewer opens it directly (its own toolbar still allows downloading)
                 top_httphead('application/pdf');
-                header('Content-Disposition: attachment; filename="' . basename($pdfFile) . '"');
+                header('Content-Disposition: inline; filename="' . basename($pdfFile) . '"');
                 header('Content-Length: ' . filesize($pdfFile));
                 readfile($pdfFile);
                 exit;


### PR DESCRIPTION
Closes #457

## Fiches PDF état du véhicule (départ / retour)

Deux nouveaux modèles de document PDF natifs (TCPDF) pour le carnet de bord, générables depuis la carte grise et depuis la PWA publique :

- **Fiche état avant/après** — par trajet terminé : tableau Départ | Retour (date, conducteur, kilométrage, carburant, commentaires, **signatures** départ/retour).
- **Fiche détails photos** — par trajet : infos + grilles « Photos départ » / « Photos retour ».

Les deux modèles s'appuient sur les helpers partagés `DolicarPdfTcpdf` / `DolicarPdfRender` (ajout de `beforeAfterGrid()`, `photoGrid()`) et un helper de données `DolicarPdfData::fetchTrips()`. Enregistrés via `addDocumentModel()` dans `modDoliCar` (réactivation du module nécessaire).

## PWA publique — écran « Trajets » + téléchargement

- Nouvel écran listant tous les trajets (prises / rendus) du véhicule, accessible via un onglet « Trajets » dans la barre de navigation, plus un lien « Voir tous les trajets » sous les derniers trajets.
- Bouton **« Télécharger la fiche état »** sur chaque trajet terminé : génère et télécharge la fiche état avant/après **limitée à ce trajet** (action publique `download_trip_pdf`, protégée par `SATURNE_ENABLE_PUBLIC_INTERFACE` et contrôle d'appartenance du trajet au véhicule).
- Les photos de trajet sont désormais rangées dans des sous-dossiers `vehicle_trip/{id}/depart` et `/retour` selon la phase, pour pouvoir les afficher séparément (fallback « Photos du trajet » pour les anciens trajets). Comptage des médias rendu récursif en conséquence.

## Vérifications

- Génération réelle des deux fiches (tous trajets) et de la fiche mono-trajet sur un véhicule de test (15 trajets, signatures) — rendu PDF contrôlé.
- Écran « Trajets » rendu, téléchargement HTTP validé (`Content-Type: application/pdf`, fichier PDF valide), contrôles de sécurité (trajet inexistant / autre véhicule → redirection).
