### PR TITLE
#466 [VehicleLogBook] feat: default mileage, photo upload fix, thumbnail CSS, state sheet photos

### DIFF
--- a/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php
+++ b/core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php
@@ -213,6 +213,20 @@ class pdf_vehiclestatesheet
                     ['label' => $outputLangs->transnoentities('Signature'), 'image' => true, 'leftImg' => $trip['start_signature'], 'rightImg' => $trip['end_signature']],
                 ]
             );
+            $render->spacer(3);
+
+            // Départ / retour photos taken through the public logbook media block
+            if (!empty($trip['legacy_photos'])) {
+                // Trip recorded before the départ/retour split (issue #457): one combined section
+                $render->sectionTitle($outputLangs->transnoentities('TripPhotos'));
+                $render->photoGrid($trip['legacy_photos'], $outputLangs->transnoentities('NoPhoto'));
+            } else {
+                $render->sectionTitle($outputLangs->transnoentities('PhotosDeparture'));
+                $render->photoGrid($trip['depart_photos'], $outputLangs->transnoentities('NoPhoto'));
+                $render->spacer(3);
+                $render->sectionTitle($outputLangs->transnoentities('PhotosReturn'));
+                $render->photoGrid($trip['return_photos'], $outputLangs->transnoentities('NoPhoto'));
+            }
             $render->spacer(5);
         }
 

--- a/core/tpl/public_vehicle_logbook_form.tpl.php
+++ b/core/tpl/public_vehicle_logbook_form.tpl.php
@@ -119,6 +119,7 @@ $isDepart = ($actionType === 'depart');
                                name="options_starting_mileage"
                                class="plv2-km-input"
                                min="<?php echo $minKm; ?>"
+                               value="<?php echo $minKm > 0 ? $minKm : ''; ?>"
                                placeholder="000000"
                                required>
                         <?php if ($minKm > 0) : ?>
@@ -128,13 +129,14 @@ $isDepart = ($actionType === 'depart');
                         <?php endif; ?>
                     <?php else :
                         $startKm    = (int) ($lastUnfinishedActionComm[0]->array_options['options_starting_mileage'] ?? 0);
-                        $minKmRetour = $startKm > 0 ? $startKm + 1 : 0;
+                        $minKmRetour = $startKm > 0 ? $startKm : 0;
                         $maxKmRetour = $startKm + getDolGlobalInt('DOLICAR_PUBLIC_MAX_ARRIVAL_MILEAGE', 1000); ?>
                         <input type="number"
                                name="options_arrival_mileage"
                                class="plv2-km-input"
                                min="<?php echo $minKmRetour; ?>"
                                max="<?php echo $maxKmRetour; ?>"
+                               value="<?php echo $startKm > 0 ? $startKm : ''; ?>"
                                placeholder="000000"
                                required>
                         <?php if ($startKm > 0) : ?>

--- a/css/dolicar.min.css
+++ b/css/dolicar.min.css
@@ -618,6 +618,19 @@
 .page-public-card .plv2-app .dolicar-trip-media-row .saturne-upload-label i {
   font-size: 15px;
 }
+.page-public-card .plv2-app .dolicar-problem-media-row .open-media-editor-as-gallery,
+.page-public-card .plv2-app .dolicar-trip-media-row .open-media-editor-as-gallery {
+  width: 38px;
+  min-width: 38px;
+  height: 38px;
+  min-height: 38px;
+  margin-left: 3px;
+  border-radius: 8px;
+}
+.page-public-card .plv2-app .dolicar-problem-media-row .open-media-editor-as-gallery img,
+.page-public-card .plv2-app .dolicar-trip-media-row .open-media-editor-as-gallery img {
+  border-radius: 8px !important;
+}
 .page-public-card .plv2-app .plv2-form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/css/scss/pages/_vehicle-logbook.scss
+++ b/css/scss/pages/_vehicle-logbook.scss
@@ -649,6 +649,20 @@
 
         i { font-size: 15px; }
       }
+
+      // Photo thumbnail: match the 38x38 icon buttons (Saturne defaults to 50x50) and
+      // space it from the camera button. The margin lives on the thumbnail itself — not on
+      // the upload-block gap — so an empty gallery never leaves a phantom gap before a photo.
+      .open-media-editor-as-gallery {
+        width: 38px;
+        min-width: 38px;
+        height: 38px;
+        min-height: 38px;
+        margin-left: 3px;
+        border-radius: 8px;
+
+        img { border-radius: 8px !important; }
+      }
     }
 
     .plv2-form-row {

--- a/public/agenda/public_vehicle_logbook.php
+++ b/public/agenda/public_vehicle_logbook.php
@@ -754,5 +754,12 @@ $(document).on('change', '#driver_socid', function () {
 </script>
 
 <?php
+// Photo editor modal — required by saturne_render_media_block() photo uploads on the trip /
+// problem / repair screens. Its DOM (#saturne-photo-editor-modal) must exist at page load,
+// otherwise window.saturne.photoEditor.open() returns silently and selecting a photo does nothing.
+if (in_array($showScreen, ['form', 'problem', 'repair'], true)) {
+    include dol_buildpath('/saturne/core/tpl/medias/photo_editor_modal.tpl.php');
+}
+
 llxFooter('', 'public');
 $db->close();


### PR DESCRIPTION
## Changements

### [VehicleLogBook] Kilométrage par défaut (prise / rendu)
- Pré-remplissage du champ kilométrage avec le dernier km connu (dernière arrivée à la prise, départ du trajet en cours au rendu).
- `min` du champ retour assoupli à la valeur de départ pour que la valeur par défaut reste valide.

### [VehicleLogBook] Correction de l'upload photo (page publique)
- Inclusion du modal éditeur photo Saturne (`photo_editor_modal.tpl.php`) sur les écrans prise/rendu, signalement et réparation. Sans ce DOM, `window.saturne.photoEditor.open()` sortait en silence et l'upload ne se déclenchait pas (aucune erreur affichée).

### [SCSS] Vignette photo du bloc média
- Vignette ramenée de 50×50 à 38×38 pour s'aligner sur les boutons, avec un léger espace (~3 px) par rapport au bouton appareil photo.
- Recompilation de `dolicar.min.css`.

### [VehicleLogBook] Photos départ / retour dans la fiche état PDF
- Ajout des sections « Photos départ » / « Photos retour » dans `pdf_vehiclestatesheet` (repli « Photos du trajet » pour les anciens trajets). La donnée était déjà chargée par `DolicarPdfData::fetchTrips`, elle n'était simplement jamais rendue.

## Fichiers modifiés
- `core/tpl/public_vehicle_logbook_form.tpl.php`
- `public/agenda/public_vehicle_logbook.php`
- `css/scss/pages/_vehicle-logbook.scss`
- `css/dolicar.min.css`
- `core/modules/dolicar/dolicardocuments/vehiclelogbookdocument/pdf_vehiclestatesheet.modules.php`

## Issue
Closes #466
