### PR TITLE
#464 [VehicleHistory] feat: pdf preview magnifier on linked documents

### DIFF
--- a/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
+++ b/core/tpl/registrationcertificatefr_vehicle_history.tpl.php
@@ -143,6 +143,7 @@ if (!empty($eventsList)) {
             if ($tmpFac->fetch($facId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpFac->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpFac, 'facture', $conf->facture->dir_output);
                 $linkedHtml .= ' &mdash; <strong>' . price($tmpFac->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($tmpFac->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpFac->note_public, 80)) . '</span>';
@@ -158,6 +159,7 @@ if (!empty($eventsList)) {
             if ($tmpPropal->fetch($propalId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpPropal->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpPropal, 'propal', $conf->propal->dir_output);
                 $linkedHtml .= ' &mdash; <strong>' . price($tmpPropal->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($tmpPropal->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpPropal->note_public, 80)) . '</span>';
@@ -173,6 +175,7 @@ if (!empty($eventsList)) {
             if ($tmpExpenseReport->fetch($expenseReportId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpExpenseReport->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpExpenseReport, 'expensereport', $conf->expensereport->dir_output);
                 $linkedHtml .= ' &mdash; <strong>' . price($tmpExpenseReport->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($tmpExpenseReport->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpExpenseReport->note_public, 80)) . '</span>';
@@ -188,6 +191,7 @@ if (!empty($eventsList)) {
             if ($tmpSupplierOrder->fetch($supplierOrderId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpSupplierOrder->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpSupplierOrder, 'commande_fournisseur', $conf->fournisseur->commande->dir_output);
                 $linkedHtml .= ' &mdash; <strong>' . price($tmpSupplierOrder->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($tmpSupplierOrder->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpSupplierOrder->note_public, 80)) . '</span>';
@@ -203,6 +207,7 @@ if (!empty($eventsList)) {
             if ($tmpSupplierInvoice->fetch($supplierInvoiceId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpSupplierInvoice->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpSupplierInvoice, 'facture_fournisseur', $conf->fournisseur->facture->dir_output);
                 $linkedHtml .= ' &mdash; <strong>' . price($tmpSupplierInvoice->total_ttc) . ' ' . $conf->currency . '</strong>';
                 if (!empty($tmpSupplierInvoice->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpSupplierInvoice->note_public, 80)) . '</span>';
@@ -218,6 +223,7 @@ if (!empty($eventsList)) {
             if ($tmpControl->fetch($controlId) > 0) {
                 $linkedHtml .= '<div class="inline-block">';
                 $linkedHtml .= $tmpControl->getNomUrl(1);
+                $linkedHtml .= dolicar_vehicle_event_doc_preview_link($tmpControl, 'digiquali', $conf->digiquali->dir_output);
                 $linkedHtml .= ' &mdash; ' . $tmpControl->getLibVerdict(4);
                 if (!empty($tmpControl->note_public)) {
                     $linkedHtml .= ' &mdash; <span class="opacitymedium">' . dol_escape_htmltag(dol_trunc($tmpControl->note_public, 80)) . '</span>';

--- a/lib/dolicar_registrationcertificatefr.lib.php
+++ b/lib/dolicar_registrationcertificatefr.lib.php
@@ -130,6 +130,58 @@ function dolicar_vehicle_event_type_enabled(string $const): bool
 }
 
 /**
+ * Build a "magnifier" link opening a linked object's last generated PDF in the Dolibarr
+ * document preview modal (used in the vehicle history "linked documents" column).
+ *
+ * last_main_doc is stored relative to the data root, i.e. it carries the module sub-dir prefix
+ * (e.g. "propale/REF/REF.pdf" — note the module dir name may differ from the modulepart, like
+ * "propale" vs "propal"). document.php resolves the modulepart to $dirOutput, so the path handed to
+ * getAdvancedPreviewUrl() must be relative to that dir: the module output dir is stripped from the
+ * real file path. The loupe is only rendered when the physical file actually exists, so a stale
+ * last_main_doc never yields a broken "file does not exist" preview.
+ *
+ * @param  CommonObject $linkedObject Linked object carrying last_main_doc + entity (already fetched)
+ * @param  string       $modulePart   document.php modulepart matching the object type (e.g. 'facture')
+ * @param  string       $dirOutput    Absolute module output dir, i.e. $conf->{module}->dir_output
+ * @return string                     HTML <a> with a search-plus picto, or '' when nothing to preview
+ */
+function dolicar_vehicle_event_doc_preview_link($linkedObject, string $modulePart, string $dirOutput): string
+{
+    global $langs;
+
+    if (empty($linkedObject->last_main_doc) || empty($dirOutput)) {
+        return '';
+    }
+
+    // last_main_doc is relative to DOL_DATA_ROOT — no loupe when the file is gone
+    $absFile = DOL_DATA_ROOT . '/' . $linkedObject->last_main_doc;
+    if (!dol_is_file($absFile)) {
+        return '';
+    }
+
+    // Path relative to the modulepart base dir. Use the real module output dir (not a guessed name)
+    // so quirks like "propale" vs "propal" resolve correctly. Fallback to <ref>/<file> if the dir
+    // is not a prefix of the file (unexpected layout).
+    $dirOutput    = rtrim($dirOutput, '/');
+    $relativePath = (strpos($absFile, $dirOutput . '/') === 0)
+        ? substr($absFile, strlen($dirOutput) + 1)
+        : dol_sanitizeFileName($linkedObject->ref) . '/' . basename($absFile);
+
+    $preview = getAdvancedPreviewUrl($modulePart, $relativePath, 1, '&entity=' . (int) $linkedObject->entity);
+    if (empty($preview) || empty($preview['url'])) {
+        return '';
+    }
+
+    return ' <a href="' . $preview['url'] . '"'
+        . (!empty($preview['css']) ? ' class="' . $preview['css'] . '"' : '')
+        . (!empty($preview['mime']) ? ' mime="' . $preview['mime'] . '"' : '')
+        . (!empty($preview['target']) ? ' target="' . $preview['target'] . '"' : '')
+        . ' title="' . dol_escape_htmltag($langs->trans('Preview')) . '">'
+        . img_picto($langs->trans('Preview'), 'search-plus')
+        . '</a>';
+}
+
+/**
  * Normalize with regex registration number field
  *
  * @param  string $registrationNumber Registration number


### PR DESCRIPTION
## Changements

- Ajout d'une **loupe d'aperçu** ouvrant le PDF du document lié dans la modale de prévisualisation Dolibarr, sur la colonne « Documents liés » de l'historique véhicule.
- Nouveau helper `dolicar_vehicle_event_doc_preview_link()` (idiome standard `getAdvancedPreviewUrl`), branché sur les 6 types de documents : facture, proposition, note de frais, commande fournisseur, facture fournisseur, contrôle DigiQuali.
- Le chemin est résolu à partir du vrai `dir_output` du module (gère les quirks de nommage comme `propale` vs `propal`), et la loupe ne s'affiche que si le PDF existe réellement sur le disque — pas d'aperçu « fichier introuvable ».

## Fichiers modifiés
- `lib/dolicar_registrationcertificatefr.lib.php`
- `core/tpl/registrationcertificatefr_vehicle_history.tpl.php`

## Issue
Cette PR couvre uniquement la case **« Loupe afin de voir le pdf en pop-up »** de #464.
Les autres tâches (remontée automatique des factures, kilométrage, montant) restent à faire.

Refs #464
