### PR TITLE
#470 [PublicControl] feat: expose registration certificate documents on public control tab

### DIFF
--- a/class/actions_dolicar.class.php
+++ b/class/actions_dolicar.class.php
@@ -483,6 +483,70 @@ class ActionsDoliCar
     }
 
     /**
+     * Overloading the digiqualiLinkedObjectDocumentation function : replacing the parent's function with the one below
+     *
+     * Adds the shared files and links of the registration certificates bound to the lot to the public control
+     * documentation tab, which otherwise only exposes those of the lot and of its parent product.
+     *
+     * @param  array  $parameters Hook metadata (context, etc...)
+     * @param  object $object     Linked object (productlot expected)
+     * @return int                0 < on error, 0 on success, 1 to replace standard code
+     * @throws Exception
+     */
+    public function digiqualiLinkedObjectDocumentation(array $parameters, $object): int
+    {
+        global $langs;
+
+        if (strpos($parameters['context'], 'publiccontrol') === false || !is_object($object) || $object->element != 'productlot') {
+            return 0;
+        }
+
+        $registrationCertificateFr = new RegistrationCertificateFr($this->db);
+        $registrationCertificates  = $registrationCertificateFr->fetchAll('', '', 0, 0, ['customsql' => 't.fk_lot = ' . (int) $object->id]);
+        if (!is_array($registrationCertificates) || empty($registrationCertificates)) {
+            return 0;
+        }
+
+        // Load Dolibarr libraries
+        require_once DOL_DOCUMENT_ROOT . '/core/class/link.class.php';
+        require_once DOL_DOCUMENT_ROOT . '/ecm/class/ecmfiles.class.php';
+
+        $langs->load('dolicar@dolicar');
+
+        $link     = new Link($this->db);
+        $ecmFiles = new EcmFiles($this->db);
+
+        // Only files shared through a link are downloadable from the public interface
+        $ecmFiles->fetchAll('', '', 0, 0, 't.share:isnot:null');
+
+        $files = [];
+        $links = [];
+        foreach ($registrationCertificates as $registrationCertificate) {
+            $nameField = img_picto('', 'fontawesome_fa-car_fas_#d35968', 'class="pictofixedwidth"') . dol_escape_htmltag($registrationCertificate->ref);
+
+            if (is_array($ecmFiles->lines)) {
+                foreach ($ecmFiles->lines as $ecmFilesLine) {
+                    if ($ecmFilesLine->src_object_type == $registrationCertificate->table_element && $ecmFilesLine->src_object_id == $registrationCertificate->id) {
+                        $ecmFilesLine->name_field = $nameField;
+                        $files[]                  = $ecmFilesLine;
+                    }
+                }
+            }
+
+            $certificateLinks = [];
+            $link->fetchAll($certificateLinks, $registrationCertificate->element, $registrationCertificate->id);
+            foreach ($certificateLinks as $certificateLink) {
+                $certificateLink->name_field = $nameField;
+                $links[]                     = $certificateLink;
+            }
+        }
+
+        $this->results = ['files' => $files, 'links' => $links];
+
+        return 0; // or return 1 to replace standard code
+    }
+
+    /**
      * Overloading the saturneSetVarsFromFetchObj function : replacing the parent's function with the one below
      *
      * @param  array $parameters Hook metadata (context, etc...)


### PR DESCRIPTION
## Changements

- Implémentation du hook `digiqualiLinkedObjectDocumentation` dans `ActionsDoliCar`, pour que l'onglet Documentation de l'interface publique de contrôle expose aussi les documents de la carte grise du véhicule.

Jusqu'ici cet onglet n'affichait que les fichiers partagés du lot et de son produit parent. Les pièces rattachées à la carte grise — c'est-à-dire l'essentiel des documents d'un véhicule — n'apparaissaient nulle part.

## Détail

- Récupération des cartes grises rattachées au lot via `t.fk_lot`, même requête que `printPublicControlLinkedObjectIdentity`
- Remontée de leurs fichiers ECM et de leurs liens, chaque ligne étiquetée avec le picto véhicule et la plaque d'immatriculation
- Filtre `share IS NOT NULL` conservé : sans hash de partage, le bouton `document.php?hashp=` ne pourrait rien télécharger depuis une page publique
- Garde sur le contexte `publiccontrol` et sur `element == productlot`, la méthode ne s'active nulle part ailleurs

Aucune modification du descripteur : le contexte `publiccontrol` est déjà déclaré par le module, pas de réactivation nécessaire.

## Fichiers modifiés

- `class/actions_dolicar.class.php`

## Tests

Sur `digiquali/public/control/public_control_history.php` pour un lot porteur d'une carte grise :

- la carte du fichier partagé s'affiche avec le picto véhicule et la plaque
- le lien de téléchargement répond `200 application/pdf`
- lot sans carte grise ou carte grise sans fichier partagé : le hook retourne un résultat vide, aucun warning
- `php -l` OK

## Dépendance

Nécessite le hook côté DigiQuali : Evarisk/digiquali#2491

## Issue

#470
